### PR TITLE
feat: Handle moon domains in proxy and fix status page

### DIFF
--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -327,8 +327,10 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 		celestialObjects = InitSolarSystemObjects()
 	}
 
-	// Check if it's a latency.space domain (case-insensitive)
-	if !strings.HasSuffix(strings.ToLower(host), ".latency.space") {
+	// Check if it's a latency.space domain (case-insensitive manual check)
+	suffix := ".latency.space"
+	if len(host) < len(suffix) || !strings.EqualFold(host[len(host)-len(suffix):], suffix) {
+		// Host does NOT end with ".latency.space" case-insensitively
 		return "", CelestialObject{}, ""
 	}
 

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -336,8 +336,8 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 	parts := strings.Split(host, ".")
 	numParts := len(parts)
 
-	// Basic validation (case-insensitive check for "latency" and "space")
-	if numParts < 3 || strings.ToLower(parts[numParts-1]) != "space" || strings.ToLower(parts[numParts-2]) != "latency" {
+	// Basic validation (using strings.EqualFold for case-insensitive checks)
+	if numParts < 3 || !strings.EqualFold(parts[numParts-1], "space") || !strings.EqualFold(parts[numParts-2], "latency") {
 		return "", CelestialObject{}, "" // Invalid format: doesn't end in .latency.space
 	}
 

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -238,8 +238,8 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Copy headers from original request
 	for name, values := range r.Header {
-		// Skip host header
-		if strings.ToLower(name) != "host" {
+		// Skip host header (case-insensitive check)
+		if !strings.EqualFold(name, "host") {
 			for _, value := range values {
 				proxyReq.Header.Add(name, value)
 			}
@@ -384,8 +384,8 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 		potentialBodyName := parts[numParts-3]
 		body, bodyFound := findObjectByName(celestialObjects, potentialBodyName)
 
-		// Check if body is found and is not a moon (to avoid conflict with moon.planet format)
-		if bodyFound && body.Type != "moon" {
+		// Check if body is found and is not a moon (case-insensitive check to avoid conflict with moon.planet format)
+		if bodyFound && !strings.EqualFold(body.Type, "moon") {
 			targetDomain := ""
 			if numParts >= 4 { // Only extract target if there are enough parts
 				targetDomain = strings.Join(parts[:numParts-3], ".")

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -18,11 +18,28 @@ import (
 	"syscall"
 	"time"
 
+	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Ensure tls package is used - needed for TLS configuration
 var _ = tls.Config{}
+
+// StatusEntry represents the data for a single celestial object in the status API
+type StatusEntry struct {
+	Name       string        `json:"name"`
+	Type       string        `json:"type"`
+	ParentName string        `json:"parentName,omitempty"` // Omit if empty
+	Distance   float64       `json:"distance_km"`
+	Latency    time.Duration `json:"latency_seconds"`
+	Occluded   bool          `json:"occluded"`
+}
+
+// ApiResponse is the structure for the /api/status-data endpoint response
+type ApiResponse struct {
+	Timestamp time.Time              `json:"timestamp"`
+	Objects   map[string][]StatusEntry `json:"objects"` // Keyed by object type (e.g., "planets", "moons")
+}
 
 // Server is the main latency proxy server
 type Server struct {
@@ -136,14 +153,20 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// API endpoint for status data
+	if r.URL.Path == "/api/status-data" {
+		s.handleStatusData(w, r)
+		return
+	}
+
 	// Special case for debug endpoints
 	if strings.HasPrefix(r.URL.Path, "/_debug/") {
 		s.handleDebugEndpoint(w, r)
 		return
 	}
 
-	// Handle CORS preflight for debug endpoints
-	if r.Method == "OPTIONS" && strings.HasPrefix(r.URL.Path, "/_debug/") {
+	// Handle CORS preflight for API and debug endpoints
+	if r.Method == "OPTIONS" && (strings.HasPrefix(r.URL.Path, "/_debug/") || r.URL.Path == "/api/status-data") {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
@@ -299,47 +322,73 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 		host = host[:idx]
 	}
 
-	// Not a latency.space domain
+	// Ensure celestial objects are initialized
+	if celestialObjects == nil {
+		celestialObjects = InitSolarSystemObjects()
+	}
+
+	// Check if it's a latency.space domain
 	if !strings.HasSuffix(host, ".latency.space") {
 		return "", CelestialObject{}, ""
 	}
 
-	// Extract parts: [subdomain, latency, space]
+	// Extract parts: [..., body, latency, space] or [..., moon, planet, latency, space]
 	parts := strings.Split(host, ".")
-	if len(parts) < 3 || parts[len(parts)-1] != "space" || parts[len(parts)-2] != "latency" {
-		return "", CelestialObject{}, ""
+	numParts := len(parts)
+
+	// Basic validation
+	if numParts < 3 || parts[numParts-1] != "space" || parts[numParts-2] != "latency" {
+		return "", CelestialObject{}, "" // Invalid format
 	}
 
-	// If format is domain.body.latency.space
-	// Extract the celestial body and target domain
-	if len(parts) >= 3 {
-		// The celestial body is the second-to-last part before "latency.space"
-		bodyIndex := len(parts) - 3
+	// Case 1: [target].[moon].[planet].latency.space (>= 5 parts)
+	// Case 2: [moon].[planet].latency.space (4 parts, target is empty)
+	if numParts >= 4 {
+		potentialMoonName := parts[numParts-4]
+		potentialPlanetName := parts[numParts-3]
 
-		// Everything before the celestial body is the target domain
-		targetParts := parts[:bodyIndex]
-		targetDomain := strings.Join(targetParts, ".")
+		moon, moonFound := findObjectByName(celestialObjects, potentialMoonName)
+		planet, planetFound := findObjectByName(celestialObjects, potentialPlanetName)
 
-		// Get the celestial body
-		bodyName := parts[bodyIndex]
-		celestialBody, found := findObjectByName(celestialObjects, bodyName)
-
-		if found {
-			return targetDomain, celestialBody, celestialBody.Name
+		// Check if both are found and have the correct types and relationship
+		if moonFound && planetFound && moon.Type == "moon" && (planet.Type == "planet" || planet.Type == "dwarf_planet") && moon.ParentName == planet.Name {
+			targetDomain := ""
+			if numParts >= 5 { // Only extract target if there are enough parts
+				targetDomain = strings.Join(parts[:numParts-4], ".")
+			}
+			// Return the moon as the final body
+			return targetDomain, moon, moon.Name
 		}
 	}
 
-	// Default behavior for standard celestial body subdomains
-	hostParts := strings.Split(host, ".")
-	if len(hostParts) > 0 {
-		body, found := findObjectByName(celestialObjects, hostParts[0])
-		if found {
+	// Case 3: [target].[planet].latency.space (>= 4 parts)
+	// Case 4: [planet].latency.space (3 parts, target is empty)
+	if numParts >= 3 {
+		potentialBodyName := parts[numParts-3]
+		body, bodyFound := findObjectByName(celestialObjects, potentialBodyName)
+
+		// Check if body is found and is not a moon (to avoid conflict with moon.planet format)
+		if bodyFound && body.Type != "moon" {
+			targetDomain := ""
+			if numParts >= 4 { // Only extract target if there are enough parts
+				targetDomain = strings.Join(parts[:numParts-3], ".")
+			}
+			// Return the planet/other body
+			return targetDomain, body, body.Name
+		}
+	}
+
+	// If none of the specific formats match, try the simple [body].latency.space format
+	// This handles the case where someone just goes to mars.latency.space
+	if numParts == 3 {
+		potentialBodyName := parts[0]
+		body, bodyFound := findObjectByName(celestialObjects, potentialBodyName)
+		if bodyFound {
 			return "", body, body.Name
-		} else {
-			return "", CelestialObject{}, ""
 		}
 	}
 
+	// If no valid format is found
 	return "", CelestialObject{}, ""
 }
 
@@ -472,6 +521,66 @@ func (s *Server) printCelestialDistances(w http.ResponseWriter) {
 	printObjectsByType(w, distanceEntries, "dwarf_planet")
 	printObjectsByType(w, distanceEntries, "spacecraft")
 
+}
+
+// handleStatusData provides celestial body status data as JSON
+func (s *Server) handleStatusData(w http.ResponseWriter, r *http.Request) {
+	// Set CORS and Content-Type headers
+	w.Header().Set("Access-Control-Allow-Origin", "*") // Allow requests from any origin
+	w.Header().Set("Content-Type", "application/json")
+
+	// Ensure distance data is up-to-date
+	now := time.Now()
+	calculateDistancesFromEarth(celestialObjects, now) // Refresh cache
+
+	// Prepare the response structure
+	response := ApiResponse{
+		Timestamp: now,
+		Objects:   make(map[string][]StatusEntry),
+	}
+
+	// Populate the response data
+	for _, obj := range celestialObjects {
+		if obj.Type == "star" { // Skip the Sun for this endpoint
+			continue
+		}
+
+		distEntry, found := distanceEntries[obj.Name]
+		if !found {
+			log.Printf("Warning: Distance entry not found for %s in handleStatusData", obj.Name)
+			continue // Skip if no distance data (should not happen after calculateDistances)
+		}
+
+		latency := CalculateLatency(distEntry.Distance)
+
+		entry := StatusEntry{
+			Name:       obj.Name,
+			Type:       obj.Type,
+			ParentName: obj.ParentName,
+			Distance:   distEntry.Distance,
+			Latency:    latency / time.Second, // Convert to seconds for JSON
+			Occluded:   distEntry.Occluded,
+		}
+
+		// Group objects by type
+		objectTypeKey := obj.Type + "s" // e.g., "planets", "moons"
+		response.Objects[objectTypeKey] = append(response.Objects[objectTypeKey], entry)
+	}
+
+	// Marshal the response to JSON
+	jsonData, err := json.MarshalIndent(response, "", "  ") // Use Indent for readability
+	if err != nil {
+		log.Printf("Error marshaling status data to JSON: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Write the JSON response
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(jsonData)
+	if err != nil {
+		log.Printf("Error writing JSON response for status data: %v", err)
+	}
 }
 
 // printHelp displays usage information

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -150,9 +150,9 @@ func TestParseHostForCelestialBody(t *testing.T) {
 				t.Errorf("host '%s': expected target URL '%s', got '%s'", tc.host, tc.expectedURL, actualURL)
 			}
 
-			// Check body name (case-insensitive comparison for robustness, although findObjectByName should handle it)
-			if strings.ToLower(actualBodyName) != strings.ToLower(tc.expectedBodyName) {
-				t.Errorf("host '%s': expected body name '%s', got '%s'", tc.host, tc.expectedBodyName, actualBodyName)
+			// Check body name (case-insensitive comparison)
+			if !strings.EqualFold(actualBodyName, tc.expectedBodyName) {
+				t.Errorf("host '%s': expected body name '%s' (case-insensitive), got '%s'", tc.host, tc.expectedBodyName, actualBodyName)
 			}
 
 			// Check the returned CelestialObject itself (by comparing names as a proxy, assuming names are unique in test data)

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+	"strings" // Import strings for case-insensitive comparison later
+)
+
+// Mock celestial objects for testing parseHostForCelestialBody
+var testCelestialObjects = []CelestialObject{
+	{Name: "Earth", Type: "planet"},
+	{Name: "Mars", Type: "planet"},
+	{Name: "Jupiter", Type: "planet"},
+	{Name: "Moon", Type: "moon", ParentName: "Earth"},
+	{Name: "Phobos", Type: "moon", ParentName: "Mars"},
+	{Name: "Deimos", Type: "moon", ParentName: "Mars"},
+	{Name: "Europa", Type: "moon", ParentName: "Jupiter"},
+}
+
+func TestParseHostForCelestialBody(t *testing.T) {
+	// Override the global celestialObjects with our test data for this test
+	originalCelestialObjects := celestialObjects
+	celestialObjects = testCelestialObjects
+	defer func() { celestialObjects = originalCelestialObjects }() // Restore original data after test
+
+	dummyURL, _ := url.Parse("http://example.com") // Dummy URL, path doesn't matter
+
+	testCases := []struct {
+		name         string
+		host         string
+		expectedURL  string
+		expectedBody CelestialObject // Compare the actual object
+		expectedBodyName string // Also compare the name for clarity in errors
+	}{
+		{
+			name:         "Moon format with target",
+			host:         "www.example.com.phobos.mars.latency.space",
+			expectedURL:  "www.example.com",
+			expectedBody: testCelestialObjects[4], // Phobos
+			expectedBodyName: "Phobos",
+		},
+		{
+			name:         "Moon format without target",
+			host:         "phobos.mars.latency.space",
+			expectedURL:  "",
+			expectedBody: testCelestialObjects[4], // Phobos
+			expectedBodyName: "Phobos",
+		},
+		{
+			name:         "Planet format with target",
+			host:         "www.example.com.mars.latency.space",
+			expectedURL:  "www.example.com",
+			expectedBody: testCelestialObjects[1], // Mars
+			expectedBodyName: "Mars",
+		},
+		{
+			name:         "Planet format without target",
+			host:         "mars.latency.space",
+			expectedURL:  "",
+			expectedBody: testCelestialObjects[1], // Mars
+			expectedBodyName: "Mars",
+		},
+		{
+			name:         "Invalid moon parent", // Phobos orbits Mars, not Jupiter
+			host:         "www.example.com.phobos.jupiter.latency.space",
+			expectedURL:  "", // Should fail moon check, potentially fallback or fail entirely
+			expectedBody: CelestialObject{}, // Expect empty object
+			expectedBodyName: "", // Expect empty name
+		},
+		{
+            name:         "Moon format with wrong planet type", // Earth is a planet, but Moon doesn't orbit Mars
+            host:         "www.example.com.moon.mars.latency.space",
+            expectedURL:  "",
+            expectedBody: CelestialObject{},
+            expectedBodyName: "",
+        },
+		{
+			name:         "Non-existent body",
+			host:         "www.example.com.unknown.latency.space",
+			expectedURL:  "",
+			expectedBody: CelestialObject{},
+			expectedBodyName: "",
+		},
+		{
+			name:         "Invalid format - just domain",
+			host:         "latency.space",
+			expectedURL:  "",
+			expectedBody: CelestialObject{},
+			expectedBodyName: "",
+		},
+		{
+			name:         "Invalid format - wrong TLD",
+			host:         "mars.latency.com",
+			expectedURL:  "",
+			expectedBody: CelestialObject{},
+			expectedBodyName: "",
+		},
+		{
+            name:         "Invalid format - unrelated domain",
+            host:         "example.com",
+            expectedURL:  "",
+            expectedBody: CelestialObject{},
+            expectedBodyName: "",
+        },
+		{
+			name:         "Case insensitivity - Moon format with target",
+			host:         "WWW.EXAMPLE.COM.PHOBOS.MARS.LATENCY.SPACE",
+			// Note: Go's URL/host parsing tends to lowercase the host,
+			// but our function uses the host string directly. Let's test if it handles it.
+			// The target domain extraction *should* preserve case.
+			// The body name lookup *should* be case-insensitive (handled by findObjectByName).
+			expectedURL:  "WWW.EXAMPLE.COM",
+			expectedBody: testCelestialObjects[4], // Phobos
+			expectedBodyName: "Phobos",
+		},
+		{
+            name:         "Case insensitivity - Planet format without target",
+            host:         "MARS.latency.space",
+            expectedURL:  "",
+            expectedBody: testCelestialObjects[1], // Mars
+            expectedBodyName: "Mars",
+        },
+		{
+			name:         "Host with port",
+			host:         "mars.latency.space:8080",
+			expectedURL:  "",
+			expectedBody: testCelestialObjects[1], // Mars
+			expectedBodyName: "Mars",
+		},
+		{
+            name:         "Moon format with target and port",
+            host:         "www.example.com.phobos.mars.latency.space:443",
+            expectedURL:  "www.example.com",
+            expectedBody: testCelestialObjects[4], // Phobos
+            expectedBodyName: "Phobos",
+        },
+	}
+
+	// Instantiate the server struct to call the method
+	// We don't need metrics or security for this test
+	s := &Server{}
+
+	for _, tc := range testCases {
+		// Use t.Run to create sub-tests for each case
+		t.Run(tc.name, func(t *testing.T) {
+			actualURL, actualBody, actualBodyName := s.parseHostForCelestialBody(tc.host, dummyURL)
+
+			// Check target URL
+			if actualURL != tc.expectedURL {
+				t.Errorf("host '%s': expected target URL '%s', got '%s'", tc.host, tc.expectedURL, actualURL)
+			}
+
+			// Check body name (case-insensitive comparison for robustness, although findObjectByName should handle it)
+			if strings.ToLower(actualBodyName) != strings.ToLower(tc.expectedBodyName) {
+				t.Errorf("host '%s': expected body name '%s', got '%s'", tc.host, tc.expectedBodyName, actualBodyName)
+			}
+
+			// Check the returned CelestialObject itself (by comparing names as a proxy, assuming names are unique in test data)
+			if actualBody.Name != tc.expectedBody.Name {
+                 t.Errorf("host '%s': expected body object name '%s', got '%s'", tc.host, tc.expectedBody.Name, actualBody.Name)
+            }
+		})
+	}
+}
+
+// Add a separate test for findObjectByName for robustness
+func TestFindObjectByName(t *testing.T) {
+    // Use the same test data
+    originalCelestialObjects := celestialObjects
+	celestialObjects = testCelestialObjects
+	defer func() { celestialObjects = originalCelestialObjects }()
+
+    testCases := []struct {
+        name          string
+        searchName    string
+        expectedFound bool
+        expectedName  string // Expected name if found
+    }{
+        {"Find existing planet", "Mars", true, "Mars"},
+        {"Find existing moon", "Phobos", true, "Phobos"},
+        {"Find existing case-insensitive", "phobos", true, "Phobos"},
+        {"Find existing case-insensitive upper", "MARS", true, "Mars"},
+        {"Find non-existent", "Unknown", false, ""},
+        {"Find empty string", "", false, ""},
+        {"Find planet in nil slice", "Earth", false, ""}, // Test edge case
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.name, func(t *testing.T) {
+            var objectsToSearch []CelestialObject
+            if tc.name == "Find planet in nil slice" {
+                objectsToSearch = nil
+            } else {
+                objectsToSearch = celestialObjects
+            }
+
+            foundBody, found := findObjectByName(objectsToSearch, tc.searchName)
+
+            if found != tc.expectedFound {
+                t.Errorf("searchName '%s': expected found status %v, got %v", tc.searchName, tc.expectedFound, found)
+            }
+
+            if found && foundBody.Name != tc.expectedName {
+                t.Errorf("searchName '%s': expected object name '%s', got '%s'", tc.searchName, tc.expectedName, foundBody.Name)
+            }
+
+            if !found && foundBody != (CelestialObject{}) {
+                 t.Errorf("searchName '%s': expected empty object when not found, got %+v", tc.searchName, foundBody)
+            }
+        })
+    }
+}

--- a/proxy/src/tls.go
+++ b/proxy/src/tls.go
@@ -26,7 +26,7 @@ func isValidSubdomain(host string) bool {
 	}
 
 	// Check if it's a standard subdomain (e.g., mars.latency.space)
-	if len(parts) == 3 && parts[1] == "latency" && parts[2] == "space" {
+	if len(parts) == 3 && strings.EqualFold(parts[1], "latency") && strings.EqualFold(parts[2], "space") {
 		// Verify it's a valid celestial body
 		_, found := findObjectByName(celestialObjects, parts[0])
 		if found {
@@ -35,7 +35,7 @@ func isValidSubdomain(host string) bool {
 	}
 
 	// Check if it's a moon subdomain (e.g., enceladus.saturn.latency.space)
-	if len(parts) == 4 && parts[2] == "latency" && parts[3] == "space" {
+	if len(parts) == 4 && strings.EqualFold(parts[2], "latency") && strings.EqualFold(parts[3], "space") {
 		moon, found := findObjectByName(celestialObjects, parts[1])
 		if !found {
 			return false
@@ -48,7 +48,7 @@ func isValidSubdomain(host string) bool {
 
 	// Check if it's our domain.body.latency.space format
 	// Any domain followed by a valid celestial body and latency.space is valid
-	if len(parts) >= 3 && parts[len(parts)-2] == "latency" && parts[len(parts)-1] == "space" {
+	if len(parts) >= 3 && strings.EqualFold(parts[len(parts)-2], "latency") && strings.EqualFold(parts[len(parts)-1], "space") {
 		bodyName := parts[len(parts)-3]
 		// Check if it's a valid celestial body
 		_, found := findObjectByName(celestialObjects, bodyName)

--- a/status/src/App.jsx
+++ b/status/src/App.jsx
@@ -1,58 +1,132 @@
 import React, { useState, useEffect } from 'react';
-import { LineChart, XAxis, YAxis, Tooltip, Line, ResponsiveContainer } from 'recharts';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { cn } from "@/lib/utils"; // Assuming you have a utility for class names
+
+// Helper function to format latency dynamically
+const formatLatency = (seconds) => {
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)} sec`;
+  }
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    return `${minutes.toFixed(1)} min`;
+  }
+  const hours = minutes / 60;
+  if (hours < 24) {
+    return `${hours.toFixed(1)} hours`;
+  }
+  const days = hours / 24;
+  return `${days.toFixed(1)} days`;
+};
+
+// Helper function to capitalize type names
+const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
 
 export default function StatusDashboard() {
-  const [metrics, setMetrics] = useState({});
+  const [statusData, setStatusData] = useState({ timestamp: null, objects: {} });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    const fetchMetrics = async () => {
-      const response = await fetch('/api/metrics');
-      const data = await response.json();
-      setMetrics(data);
+    const fetchStatusData = async () => {
+      setLoading(true); // Set loading true at the start of fetch
+      setError(null);   // Clear previous errors
+      try {
+        const response = await fetch('/api/status-data');
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        setStatusData(data);
+      } catch (e) {
+        console.error("Failed to fetch status data:", e);
+        setError(`Failed to load data: ${e.message}`);
+      } finally {
+        setLoading(false);
+      }
     };
 
-    fetchMetrics();
-    const interval = setInterval(fetchMetrics, 5000);
+    fetchStatusData();
+    const interval = setInterval(fetchStatusData, 15000); // Fetch every 15 seconds
     return () => clearInterval(interval);
   }, []);
 
+  // Define the desired order of object types
+  const typeOrder = ['planets', 'dwarf_planets', 'moons', 'asteroids', 'spacecraft'];
+
+  // Get sorted object types based on the defined order
+  const sortedObjectTypes = Object.keys(statusData.objects || {})
+    .filter(type => statusData.objects[type]?.length > 0) // Only include types with objects
+    .sort((a, b) => {
+      const indexA = typeOrder.indexOf(a);
+      const indexB = typeOrder.indexOf(b);
+      if (indexA === -1 && indexB === -1) return a.localeCompare(b); // Both not in order, sort alphabetically
+      if (indexA === -1) return 1;  // a not in order, comes after
+      if (indexB === -1) return -1; // b not in order, comes after
+      return indexA - indexB;       // Both in order, sort by index
+    });
+
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 p-8">
+    <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 p-8 text-white">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-4xl font-bold text-white mb-8">Solar System Latency Status</h1>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {Object.entries(metrics.planets || {}).map(([planet, data]) => (
-            <Card key={planet} className="bg-white/10 text-white">
-              <CardHeader>
-                <CardTitle>{planet}.latency.space</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4">
-                  <div>
-                    <p className="text-sm text-gray-300">Current Distance</p>
-                    <p className="text-2xl">{(data.distance / 1e6).toFixed(1)}M km</p>
-                  </div>
-                  <div>
-                    <p className="text-sm text-gray-300">Light Travel Time</p>
-                    <p className="text-2xl">{(data.latency / 60).toFixed(1)} minutes</p>
-                  </div>
-                  <div className="h-32">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={data.history}>
-                        <XAxis dataKey="time" stroke="#fff" />
-                        <YAxis stroke="#fff" />
-                        <Tooltip />
-                        <Line type="monotone" dataKey="latency" stroke="#8884d8" />
-                      </LineChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <h1 className="text-4xl font-bold mb-4">Solar System Latency Status</h1>
+        {statusData.timestamp && (
+          <p className="text-sm text-gray-400 mb-8">
+            Last updated: {new Date(statusData.timestamp).toLocaleString()}
+          </p>
+        )}
+
+        {loading && <p>Loading celestial data...</p>}
+        {error && <p className="text-red-500">{error}</p>}
+
+        {!loading && !error && sortedObjectTypes.map(objectType => (
+          <div key={objectType} className="mb-10">
+            <h2 className="text-3xl font-semibold mb-6 border-b border-gray-600 pb-2">
+              {capitalize(objectType.replace('_', ' '))}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {(statusData.objects[objectType] || [])
+                // Optional: Sort objects within a type, e.g., by distance
+                .sort((a, b) => a.distance_km - b.distance_km)
+                .map((obj) => (
+                  <Card key={obj.Name} className={cn(
+                    "bg-white/10 text-white border",
+                    obj.occluded ? "border-red-600/50" : "border-cyan-600/50"
+                  )}>
+                    <CardHeader>
+                      <CardTitle className="flex justify-between items-center">
+                        <span>{obj.Name}</span>
+                        <span className={cn(
+                          "text-xs font-semibold px-2 py-0.5 rounded-full",
+                          obj.occluded ? "bg-red-700" : "bg-green-700"
+                        )}>
+                          {obj.occluded ? 'Occluded' : 'Visible'}
+                        </span>
+                      </CardTitle>
+                      {obj.ParentName && (
+                         <p className="text-xs text-gray-400 -mt-2">Orbiting {obj.ParentName}</p>
+                      )}
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-3">
+                        <div>
+                          <p className="text-sm text-gray-400">Current Distance</p>
+                          <p className="text-xl">{(obj.distance_km / 1e6).toFixed(1)}M km</p>
+                        </div>
+                        <div>
+                          <p className="text-sm text-gray-400">One-Way Latency</p>
+                          <p className="text-xl">{formatLatency(obj.latency_seconds)}</p>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+              ))}
+            </div>
+          </div>
+        ))}
+        {!loading && !error && sortedObjectTypes.length === 0 && (
+           <p>No celestial object data available.</p>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Proxy Domain Parsing:**
    - Modified the `parseHostForCelestialBody` function in `proxy/src/main.go` to correctly parse hostnames that include moons, such as `target.moon.planet.latency.space`.
    - The logic now identifies the moon as the target celestial body and verifies its parent planet relationship.
    - Added comprehensive unit tests in `proxy/src/main_test.go` to cover moon formats, planet formats, invalid inputs, and edge cases.

2.  **Status Website:**
    - Created a new API endpoint `/api/status-data` in `proxy/src/main.go` that returns current celestial body distances, latencies, and occlusion status in JSON format.
    - Updated the `StatusDashboard` component in `status/src/App.jsx` to fetch data from the new `/api/status-data` endpoint instead of the incorrect `/api/metrics` endpoint.
    - Refactored the component to display the snapshot data (name, distance, latency, occlusion) correctly for planets, moons, and other objects, resolving the issue where the page previously displayed nothing.

These changes allow you to specify moons in the latency simulation domain and fix the non-functional status dashboard.