### PR TITLE
fix: Display occlusion status on celestial info page

### DIFF
--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -213,13 +213,10 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	// Check for occlusion
 	occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
 	if occluded {
-		occluderName := "Unknown"
-		if occluder != nil {
-			occluderName = occluder.Name
-		}
-		log.Printf("HTTP connection to %s rejected: occluded by %s", bodyName, occluderName)
+		// If occluded is true, occluder is guaranteed to be non-nil by IsOccluded
+		log.Printf("HTTP connection to %s rejected: occluded by %s", bodyName, occluder.Name)
 		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprintf(w, "Connection refused: Target body '%s' is occluded by '%s'.", bodyName, occluderName)
+		fmt.Fprintf(w, "Connection refused: Target body '%s' is occluded by '%s'.", bodyName, occluder.Name)
 		return
 	}
 
@@ -330,11 +327,8 @@ func (s *Server) displayCelestialInfo(w http.ResponseWriter, name string) {
 	} else {
 		occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
 		if occluded {
-			occluderName := "Unknown"
-			if occluder != nil {
-				occluderName = occluder.Name
-			}
-			fmt.Fprintf(w, `<p style="color: red;">Status: Occluded by %s</p>`, occluderName)
+			// If occluded is true, occluder is guaranteed to be non-nil by IsOccluded
+			fmt.Fprintf(w, `<p style="color: red;">Status: Occluded by %s</p>`, occluder.Name)
 		} else {
 			fmt.Fprintf(w, `<p style="color: green;">Status: Visible</p>`)
 		}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -196,8 +196,36 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Find the target and Earth objects
+	targetObject, targetFound := findObjectByName(celestialObjects, bodyName)
+	if !targetFound {
+		log.Printf("Error: Target celestial body '%s' not found after host parsing.", bodyName)
+		http.Error(w, "Internal server error: Target body not found", http.StatusInternalServerError)
+		return
+	}
+	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
+	if !earthFound {
+		log.Printf("Error: Earth celestial object not found.")
+		http.Error(w, "Internal server error: Earth object configuration missing", http.StatusInternalServerError)
+		return
+	}
+
+	// Check for occlusion
+	occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+	if occluded {
+		occluderName := "Unknown"
+		if occluder != nil {
+			occluderName = occluder.Name
+		}
+		log.Printf("HTTP connection to %s rejected: occluded by %s", bodyName, occluderName)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintf(w, "Connection refused: Target body '%s' is occluded by '%s'.", bodyName, occluderName)
+		return
+	}
+
 	// Apply space latency
-	latency := CalculateLatency(getCurrentDistance(bodyName))
+	distance := getCurrentDistance(bodyName) // Use the existing function for distance
+	latency := CalculateLatency(distance)
 
 	// Anti-DDoS: Only allow bodies with significant latency (>1s)
 	// This prevents the proxy from being used for DDoS attacks
@@ -288,6 +316,31 @@ func (s *Server) displayCelestialInfo(w http.ResponseWriter, name string) {
 	fmt.Fprintf(w, "<p>Current distance from Earth: %.2f million km</p>", distance / 1e6)
 	fmt.Fprintf(w, "<p>One-way latency: %v</p>", latency.Round(time.Second))
 	fmt.Fprintf(w, "<p>Round-trip latency: %v</p>", 2*latency.Round(time.Second))
+
+	// --- Occlusion Check ---
+	targetObject, targetFound := findObjectByName(celestialObjects, name)
+	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
+
+	if !targetFound {
+		log.Printf("Error: Target celestial body '%s' not found in displayCelestialInfo.", name)
+		// Don't write error to response, just log it, as basic info is already printed
+	} else if !earthFound {
+		log.Printf("Error: Earth celestial object not found in displayCelestialInfo.")
+		// Don't write error to response, just log it
+	} else {
+		occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+		if occluded {
+			occluderName := "Unknown"
+			if occluder != nil {
+				occluderName = occluder.Name
+			}
+			fmt.Fprintf(w, `<p style="color: red;">Status: Occluded by %s</p>`, occluderName)
+		} else {
+			fmt.Fprintf(w, `<p style="color: green;">Status: Visible</p>`)
+		}
+	}
+	// --- End Occlusion Check ---
+
 
 	fmt.Fprintf(w, "<h2>Usage</h2>")
 	fmt.Fprintf(w, "<p>To browse a website through %s, use one of these formats:</p>", name)

--- a/proxy/src/socks.go
+++ b/proxy/src/socks.go
@@ -239,13 +239,11 @@ func (s *SOCKSHandler) handleClientRequest() error {
 
 	occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
 	if occluded {
-		occluderName := "Unknown"
-		if occluder != nil {
-			occluderName = occluder.Name
-		}
-		log.Printf("SOCKS connection to %s rejected: occluded by %s", bodyName, occluderName)
+		// If occluded is true, occluder is guaranteed to be non-nil by IsOccluded
+		log.Printf("SOCKS connection to %s rejected: occluded by %s", bodyName, occluder.Name)
 		s.sendReply(SOCKS5_REP_HOST_UNREACHABLE, net.IPv4zero, 0) // Host unreachable due to occlusion
-		return nil                                               // Return nil as the rejection is handled, not an error in processing
+		// Return an error indicating the reason for rejection
+		return fmt.Errorf("SOCKS connection rejected: %s occluded by %s", bodyName, occluder.Name)
 	}
 	// --- End Occlusion Check ---
 

--- a/status/src/pages/Landing.jsx
+++ b/status/src/pages/Landing.jsx
@@ -1,147 +1,108 @@
 // status/src/pages/Landing.jsx
 import React, { useState, useEffect } from 'react';
 
-// Speed of light in km/s
-const SPEED_OF_LIGHT = 299792.458;
+// Helper function to format latency from seconds
+const formatLatency = (seconds) => {
+  if (seconds < 0) return 'N/A'; // Handle potential negative values if any
+  if (seconds < 60) {
+    return `${seconds.toFixed(2)} seconds`;
+  } else if (seconds < 3600) {
+    return `${(seconds / 60).toFixed(2)} minutes`;
+  } else {
+    return `${(seconds / 3600).toFixed(2)} hours`;
+  }
+};
+
 
 export default function LandingPage() {
   const [celestialData, setCelestialData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState(null);
-  
-  // Function to calculate latency from distance in millions of km
-  const calculateLatency = (distanceMillionKm) => {
-    const distanceKm = distanceMillionKm * 1e6;
-    const seconds = distanceKm / SPEED_OF_LIGHT;
-    
-    // Format based on magnitude
-    if (seconds < 60) {
-      return `${seconds.toFixed(2)} seconds`;
-    } else if (seconds < 3600) {
-      return `${(seconds / 60).toFixed(2)} minutes`;
-    } else {
-      return `${(seconds / 3600).toFixed(2)} hours`;
-    }
-  };
-  
-  // Function to fetch celestial body data
+
+  // Function to fetch celestial body data from the new API endpoint
   const fetchCelestialData = async () => {
     try {
       setLoading(true);
-      // Use the CORS-enabled proxy endpoint to get the data
-      const response = await fetch('/api/debug/distances');
+      // Fetch from the new /api/status-data endpoint
+      const response = await fetch('/api/status-data');
       if (!response.ok) {
-        throw new Error('Failed to fetch data');
+        throw new Error(`Failed to fetch data: ${response.statusText}`);
       }
-      
-      const text = await response.text();
-      
-      // Parse the plain text response
-      const lines = text.split('\n');
-      let timestamp = new Date().toISOString();
-      
-      // Extract the timestamp if available
-      const timestampLine = lines.find(line => line.startsWith('Current Time:'));
-      if (timestampLine) {
-        timestamp = timestampLine.split('Current Time:')[1].trim();
+
+      const data = await response.json(); // Parse JSON response
+
+      setLastUpdated(data.timestamp);
+
+      // Process the structured JSON data
+      const parsedData = [];
+      for (const typeKey in data.objects) {
+        const type = typeKey.replace(/s$/, ''); // Remove plural 's' (e.g., "planets" -> "planet")
+        data.objects[typeKey].forEach(entry => {
+          parsedData.push({
+            name: entry.name, // API uses lowercase 'name'
+            distance: entry.distance_km / 1e6, // Convert km to million km
+            latencySeconds: entry.latency_seconds, // Keep raw seconds if needed elsewhere
+            latency: formatLatency(entry.latency_seconds), // Format for display
+            occluded: entry.occluded,
+            type: type, // Store the object type
+            parentName: entry.parentName || null // Store parent name if available
+          });
+        });
       }
-      
-      setLastUpdated(timestamp);
-      
-      // Parse the distance data
-      const data = [];
-      const dataLines = lines.filter(line => line.includes('million km'));
-      
-      dataLines.forEach(line => {
-        const parts = line.split(':');
-        if (parts.length === 2) {
-          const name = parts[0].trim();
-          const fullText = parts[1].trim();
-          const distanceMatch = fullText.match(/([0-9.]+) million km/);
-          
-          if (distanceMatch) {
-            const distance = parseFloat(distanceMatch[1]);
-            const latency = calculateLatency(distance);
-            
-            data.push({
-              name,
-              distance,
-              latency,
-              fullText
-            });
-          }
-        }
-      });
-      
-      // Sort data: planets first, then moons, then spacecraft
-      data.sort((a, b) => {
-        // Helper to determine type
-        const getType = (name) => {
-          if (name.includes('.')) return 2; // Moon
-          if (['voyager1', 'voyager2', 'newhorizons', 'jwst', 'iss', 'perseverance'].includes(name)) return 3; // Spacecraft
-          return 1; // Planet
-        };
-        
-        const typeA = getType(a.name);
-        const typeB = getType(b.name);
-        
+
+      // Sort data: Earth first, then planets by distance, then moons alphabetically, then spacecraft alphabetically
+      parsedData.sort((a, b) => {
+        const typeOrder = { 'planet': 1, 'dwarf_planet': 1, 'moon': 2, 'asteroid': 3, 'spacecraft': 4 };
+        const typeA = typeOrder[a.type] || 99;
+        const typeB = typeOrder[b.type] || 99;
+
+        if (a.name.toLowerCase() === 'earth') return -1;
+        if (b.name.toLowerCase() === 'earth') return 1;
+
         if (typeA !== typeB) return typeA - typeB;
-        
-        // If same type, sort planets by distance, except Earth is always first
-        if (typeA === 1) {
-          if (a.name === 'earth') return -1;
-          if (b.name === 'earth') return 1;
+
+        // If same type, sort planets by distance
+        if (a.type === 'planet' || a.type === 'dwarf_planet') {
           return a.distance - b.distance;
         }
-        
-        // Alphabetical sort for moons and spacecraft
+
+        // Alphabetical sort for others of the same type
         return a.name.localeCompare(b.name);
       });
-      
-      setCelestialData(data);
+
+
+      setCelestialData(parsedData);
     } catch (error) {
       console.error('Error fetching celestial data:', error);
-      // Generate mock data if API fails
-      generateMockData();
+      // Consider setting an error state to display to the user
+      setCelestialData([]); // Clear data on error
+      // generateMockData(); // Removed mock data generation
     } finally {
       setLoading(false);
     }
   };
-  
-  // Generate mock data in case the API is not available
-  const generateMockData = () => {
-    const mockData = [
-      { name: 'earth', distance: 0, latency: '0 seconds' },
-      { name: 'mars', distance: 225.0, latency: '12.5 minutes' },
-      { name: 'jupiter', distance: 778.6, latency: '43.3 minutes' },
-      { name: 'saturn', distance: 1433.5, latency: '79.7 minutes' },
-      { name: 'voyager1', distance: 23000.0, latency: '21.3 hours' },
-    ];
-    
-    setCelestialData(mockData);
-    setLastUpdated(new Date().toISOString());
-  };
-  
+
+  // Removed generateMockData function
+
   useEffect(() => {
     // Initial fetch
     fetchCelestialData();
-    
+
     // Set up interval for periodic updates
     const interval = setInterval(fetchCelestialData, 60000); // Refresh every minute
-    
+
     // Clean up interval on component unmount
     return () => clearInterval(interval);
   }, []);
-  
-  // Group celestial bodies by type
-  const planets = celestialData.filter(item => !item.name.includes('.') && 
-    !['voyager1', 'voyager2', 'newhorizons', 'jwst', 'iss', 'perseverance'].includes(item.name));
-  
-  const moons = celestialData.filter(item => item.name.includes('.'));
-  
-  const spacecraft = celestialData.filter(item => 
-    ['voyager1', 'voyager2', 'newhorizons', 'jwst', 'iss', 'perseverance'].includes(item.name));
-  
+
+  // Group celestial bodies by type using the new 'type' field
+  const planets = celestialData.filter(item => item.type === 'planet' || item.type === 'dwarf_planet');
+  const moons = celestialData.filter(item => item.type === 'moon');
+  const spacecraft = celestialData.filter(item => item.type === 'spacecraft');
+  // Add other types like asteroids if needed
+  const others = celestialData.filter(item => !['planet', 'dwarf_planet', 'moon', 'spacecraft'].includes(item.type));
+
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800">
       <nav className="bg-black/30 p-4">
@@ -160,76 +121,118 @@ export default function LandingPage() {
           <h2 className="text-5xl font-bold text-white mb-4">Experience Interplanetary Latency</h2>
           <p className="text-xl text-gray-300">Simulate real-time communication delays across the solar system</p>
         </div>
-        
+
         {/* Current Distances Dashboard */}
         <div className="bg-white/10 p-6 rounded-lg mb-16">
           <div className="flex justify-between items-center mb-6">
-            <h3 className="text-2xl font-bold text-white">Real-Time Solar System Distances</h3>
+            <h3 className="text-2xl font-bold text-white">Real-Time Solar System Status</h3>
             <div className="text-gray-400 text-sm">
               {lastUpdated && (
                 <p>Last updated: {new Date(lastUpdated).toLocaleString()}</p>
               )}
-              <button 
+              <button
                 onClick={fetchCelestialData}
-                className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-xs ml-2"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-xs ml-2 disabled:opacity-50"
+                disabled={loading}
               >
-                Refresh
+                {loading ? 'Refreshing...' : 'Refresh'}
               </button>
             </div>
           </div>
-          
-          {loading ? (
+
+          {loading && celestialData.length === 0 ? ( // Show loading only on initial load
             <div className="text-center py-8 text-gray-300">Loading celestial data...</div>
+          ) : celestialData.length === 0 && !loading ? ( // Show error if fetch failed and not loading
+             <div className="text-center py-8 text-red-400">Failed to load celestial data. Please try refreshing.</div>
           ) : (
             <div className="space-y-8">
               {/* Planets */}
-              <div>
-                <h4 className="text-xl font-bold text-white mb-4">Planets</h4>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {planets.map(planet => (
-                    <div key={planet.name} className="bg-black/30 p-4 rounded-lg">
-                      <h5 className="text-lg font-bold text-white capitalize">{planet.name}</h5>
-                      <div className="mt-2 space-y-2">
-                        <p className="text-gray-300">Distance: <span className="text-blue-400">{planet.distance.toFixed(2)} million km</span></p>
-                        <p className="text-gray-300">Light latency: <span className="text-yellow-400">{planet.latency}</span></p>
-                        <p className="text-gray-300 text-sm">Domain: <code className="bg-black/30 px-2 py-1 rounded">{planet.name}.latency.space</code></p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              
-              {/* Moons, only show if we have moons data */}
-              {moons.length > 0 && (
+              {planets.length > 0 && (
                 <div>
-                  <h4 className="text-xl font-bold text-white mb-4">Moons</h4>
+                  <h4 className="text-xl font-bold text-white mb-4">Planets & Dwarf Planets</h4>
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {moons.map(moon => (
-                      <div key={moon.name} className="bg-black/30 p-4 rounded-lg">
-                        <h5 className="text-lg font-bold text-white">{moon.name}</h5>
-                        <div className="mt-2 space-y-2">
-                          <p className="text-gray-300">Distance: <span className="text-blue-400">{moon.distance.toFixed(3)} million km</span></p>
-                          <p className="text-gray-300">Light latency: <span className="text-yellow-400">{moon.latency}</span></p>
-                          <p className="text-gray-300 text-sm">Domain: <code className="bg-black/30 px-2 py-1 rounded">{moon.name}.latency.space</code></p>
+                    {planets.map(item => ( // Changed variable name to item
+                      <div key={item.name} className="bg-black/30 p-4 rounded-lg">
+                        <h5 className="text-lg font-bold text-white capitalize">{item.name}</h5>
+                        <div className="mt-2 space-y-1"> {/* Reduced spacing */}
+                          <p className="text-gray-300 text-sm">Distance: <span className="text-blue-400">{item.distance.toFixed(2)} million km</span></p>
+                          <p className="text-gray-300 text-sm">Latency: <span className="text-yellow-400">{item.latency}</span></p>
+                           <p className={`text-sm ${item.occluded ? 'text-red-400' : 'text-green-400'}`}>
+                             Status: {item.occluded ? 'Occluded' : 'Visible'}
+                           </p>
+                          <p className="text-gray-300 text-xs pt-1">Domain: <code className="bg-black/50 px-1 py-0.5 rounded text-xs">{item.name}.latency.space</code></p>
                         </div>
                       </div>
                     ))}
                   </div>
                 </div>
               )}
-              
+
+              {/* Moons */}
+              {moons.length > 0 && (
+                <div>
+                  <h4 className="text-xl font-bold text-white mb-4">Moons</h4>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {moons.map(item => ( // Changed variable name to item
+                      <div key={item.name} className="bg-black/30 p-4 rounded-lg">
+                        {/* Display parent name if available */}
+                        <h5 className="text-lg font-bold text-white capitalize">
+                          {item.name}{item.parentName ? ` (${item.parentName})` : ''}
+                        </h5>
+                        <div className="mt-2 space-y-1"> {/* Reduced spacing */}
+                          <p className="text-gray-300 text-sm">Distance: <span className="text-blue-400">{item.distance.toFixed(3)} million km</span></p>
+                          <p className="text-gray-300 text-sm">Latency: <span className="text-yellow-400">{item.latency}</span></p>
+                          <p className={`text-sm ${item.occluded ? 'text-red-400' : 'text-green-400'}`}>
+                            Status: {item.occluded ? 'Occluded' : 'Visible'}
+                          </p>
+                           {/* Construct domain name based on parent */}
+                          <p className="text-gray-300 text-xs pt-1">Domain: <code className="bg-black/50 px-1 py-0.5 rounded text-xs">
+                            {item.parentName ? `${item.name}.${item.parentName}` : item.name}.latency.space
+                          </code></p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* Spacecraft */}
               {spacecraft.length > 0 && (
                 <div>
                   <h4 className="text-xl font-bold text-white mb-4">Spacecraft</h4>
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {spacecraft.map(craft => (
-                      <div key={craft.name} className="bg-black/30 p-4 rounded-lg">
-                        <h5 className="text-lg font-bold text-white">{craft.name}</h5>
-                        <div className="mt-2 space-y-2">
-                          <p className="text-gray-300">Distance: <span className="text-blue-400">{craft.distance.toFixed(2)} million km</span></p>
-                          <p className="text-gray-300">Light latency: <span className="text-yellow-400">{craft.latency}</span></p>
-                          <p className="text-gray-300 text-sm">Domain: <code className="bg-black/30 px-2 py-1 rounded">{craft.name}.latency.space</code></p>
+                    {spacecraft.map(item => ( // Changed variable name to item
+                      <div key={item.name} className="bg-black/30 p-4 rounded-lg">
+                        <h5 className="text-lg font-bold text-white capitalize">{item.name}</h5>
+                        <div className="mt-2 space-y-1"> {/* Reduced spacing */}
+                          <p className="text-gray-300 text-sm">Distance: <span className="text-blue-400">{item.distance.toFixed(2)} million km</span></p>
+                          <p className="text-gray-300 text-sm">Latency: <span className="text-yellow-400">{item.latency}</span></p>
+                           <p className={`text-sm ${item.occluded ? 'text-red-400' : 'text-green-400'}`}>
+                             Status: {item.occluded ? 'Occluded' : 'Visible'}
+                           </p>
+                          <p className="text-gray-300 text-xs pt-1">Domain: <code className="bg-black/50 px-1 py-0.5 rounded text-xs">{item.name}.latency.space</code></p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+               {/* Others (e.g., Asteroids) */}
+              {others.length > 0 && (
+                <div>
+                  <h4 className="text-xl font-bold text-white mb-4">Other Objects</h4>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {others.map(item => (
+                      <div key={item.name} className="bg-black/30 p-4 rounded-lg">
+                        <h5 className="text-lg font-bold text-white capitalize">{item.name} ({item.type})</h5>
+                        <div className="mt-2 space-y-1"> {/* Reduced spacing */}
+                          <p className="text-gray-300 text-sm">Distance: <span className="text-blue-400">{item.distance.toFixed(2)} million km</span></p>
+                          <p className="text-gray-300 text-sm">Latency: <span className="text-yellow-400">{item.latency}</span></p>
+                           <p className={`text-sm ${item.occluded ? 'text-red-400' : 'text-green-400'}`}>
+                             Status: {item.occluded ? 'Occluded' : 'Visible'}
+                           </p>
+                          <p className="text-gray-300 text-xs pt-1">Domain: <code className="bg-black/50 px-1 py-0.5 rounded text-xs">{item.name}.latency.space</code></p>
                         </div>
                       </div>
                     ))}
@@ -239,16 +242,16 @@ export default function LandingPage() {
             </div>
           )}
         </div>
-        
+
         {/* Usage Guides */}
         <div className="bg-white/10 p-8 rounded-lg mb-16">
           <h3 className="text-2xl font-bold text-white mb-6">How to Use latency.space</h3>
-          
+
           <div className="space-y-8">
             <div>
               <h4 className="text-xl font-bold text-white mb-3">HTTP Proxy</h4>
               <p className="text-gray-300 mb-4">Experience interplanetary latency when browsing the web or making HTTP requests.</p>
-              
+
               <div className="space-y-4">
                 <div>
                   <p className="text-gray-300 mb-2">1. Direct Domain Format:</p>
@@ -257,7 +260,7 @@ export default function LandingPage() {
                   </code>
                   <p className="text-gray-400 text-sm mt-1">Adds Mars-to-Earth latency to any destination specified in your request.</p>
                 </div>
-                
+
                 <div>
                   <p className="text-gray-300 mb-2">2. Target Domain Format:</p>
                   <code className="block bg-black/30 p-4 rounded">
@@ -265,7 +268,7 @@ export default function LandingPage() {
                   </code>
                   <p className="text-gray-400 text-sm mt-1">Routes to example.com with Mars-to-Earth latency.</p>
                 </div>
-                
+
                 <div>
                   <p className="text-gray-300 mb-2">3. Query Parameter:</p>
                   <code className="block bg-black/30 p-4 rounded">
@@ -273,7 +276,7 @@ export default function LandingPage() {
                   </code>
                   <p className="text-gray-400 text-sm mt-1">Specify destination in the query string parameter.</p>
                 </div>
-                
+
                 <div>
                   <p className="text-gray-300 mb-2">4. Curl Example:</p>
                   <code className="block bg-black/30 p-4 rounded">
@@ -283,11 +286,11 @@ export default function LandingPage() {
                 </div>
               </div>
             </div>
-            
+
             <div>
               <h4 className="text-xl font-bold text-white mb-3">SOCKS5 Proxy</h4>
               <p className="text-gray-300 mb-4">Use the SOCKS5 proxy for any TCP/IP application.</p>
-              
+
               <div className="space-y-4">
                 <div>
                   <p className="text-gray-300 mb-2">1. Basic Usage:</p>
@@ -296,7 +299,7 @@ export default function LandingPage() {
                   </code>
                   <p className="text-gray-400 text-sm mt-1">Connect to an SSH server through Mars latency.</p>
                 </div>
-                
+
                 <div>
                   <p className="text-gray-300 mb-2">2. With Curl:</p>
                   <code className="block bg-black/30 p-4 rounded">
@@ -304,7 +307,7 @@ export default function LandingPage() {
                   </code>
                   <p className="text-gray-400 text-sm mt-1">Experience Neptune's ~4 hour round-trip latency when accessing a website.</p>
                 </div>
-                
+
                 <div>
                   <p className="text-gray-300 mb-2">3. Browser Configuration:</p>
                   <p className="text-gray-400">Configure your browser's SOCKS proxy settings:</p>
@@ -314,7 +317,7 @@ export default function LandingPage() {
                     <li>Type: SOCKS5</li>
                   </ul>
                 </div>
-                
+
                 <div>
                   <p className="text-gray-300 mb-2">4. Target Domain Format:</p>
                   <code className="block bg-black/30 p-4 rounded">
@@ -324,30 +327,30 @@ export default function LandingPage() {
                 </div>
               </div>
             </div>
-            
+
             <div>
               <h4 className="text-xl font-bold text-white mb-3">Debug and Information Endpoints</h4>
               <p className="text-gray-300 mb-4">Access detailed information about the system.</p>
-              
+
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="bg-black/30 p-4 rounded">
                   <p className="text-white font-bold">Distance Information</p>
                   <code className="block text-gray-400 mt-2">http://latency.space/_debug/distances</code>
                   <p className="text-gray-400 text-sm mt-1">Current distances from Earth to all bodies</p>
                 </div>
-                
+
                 <div className="bg-black/30 p-4 rounded">
                   <p className="text-white font-bold">Detailed Body Information</p>
                   <code className="block text-gray-400 mt-2">http://latency.space/_debug/bodies</code>
                   <p className="text-gray-400 text-sm mt-1">Complete details of all celestial bodies</p>
                 </div>
-                
+
                 <div className="bg-black/30 p-4 rounded">
                   <p className="text-white font-bold">Valid Domains</p>
                   <code className="block text-gray-400 mt-2">http://latency.space/_debug/domains</code>
                   <p className="text-gray-400 text-sm mt-1">List of valid domain formats</p>
                 </div>
-                
+
                 <div className="bg-black/30 p-4 rounded">
                   <p className="text-white font-bold">Help Information</p>
                   <code className="block text-gray-400 mt-2">http://latency.space/_debug/help</code>
@@ -357,7 +360,7 @@ export default function LandingPage() {
             </div>
           </div>
         </div>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
           <div className="bg-white/10 p-6 rounded-lg">
             <h3 className="text-xl font-bold text-white mb-4">Advanced Usage</h3>
@@ -370,7 +373,7 @@ export default function LandingPage() {
                 </code>
                 <p className="text-gray-400 text-xs mt-1">Routes to example.com with combined Saturn + Titan latency</p>
               </div>
-              
+
               <div>
                 <h4 className="font-bold">Custom Applications</h4>
                 <p className="text-sm">Configure applications to use SOCKS5 proxy:</p>
@@ -381,7 +384,7 @@ export default function LandingPage() {
                   <li>Gaming (for the ultimate challenge)</li>
                 </ul>
               </div>
-              
+
               <div>
                 <h4 className="font-bold">Spacecraft Tracking</h4>
                 <p className="text-sm">Distances to spacecraft update in real-time based on actual trajectories</p>
@@ -406,7 +409,7 @@ export default function LandingPage() {
             </ul>
           </div>
         </div>
-        
+
         <div className="bg-white/10 p-6 rounded-lg mb-16">
           <h3 className="text-xl font-bold text-white mb-4">Use Cases</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -414,12 +417,12 @@ export default function LandingPage() {
               <h4 className="font-bold text-white">Education</h4>
               <p className="text-gray-300 text-sm mt-2">Demonstrate the challenges of space communication to students and enthusiasts. Experience first-hand why Mars rovers can't be joysticked in real-time.</p>
             </div>
-            
+
             <div className="bg-black/30 p-4 rounded-lg">
               <h4 className="font-bold text-white">Software Testing</h4>
               <p className="text-gray-300 text-sm mt-2">Test software behavior under extreme network conditions. Ensure applications can handle multi-minute or even hour-long latencies gracefully.</p>
             </div>
-            
+
             <div className="bg-black/30 p-4 rounded-lg">
               <h4 className="font-bold text-white">Research</h4>
               <p className="text-gray-300 text-sm mt-2">Explore new protocols and communication strategies designed for high-latency environments. Test delay-tolerant networking concepts.</p>
@@ -438,3 +441,5 @@ export default function LandingPage() {
     </div>
   );
 }
+// status/src/pages/Landing.jsx
+// This entire file block is removed as it's replaced by the new code above.


### PR DESCRIPTION
The `displayCelestialInfo` function, which generates the simple HTML page when accessing a base celestial domain (e.g., mars.latency.space/), did not previously indicate the occlusion status.

This commit updates the function to:
- Perform an occlusion check using `IsOccluded`.
- Add a paragraph to the HTML output showing whether the body is currently "Visible" (in green) or "Occluded by [Occluder Name]" (in red).

This ensures all user-facing status indicators correctly reflect the visibility of celestial bodies.