### PR TITLE
fix(deploy): Rebuild containers on deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,7 +250,7 @@ jobs:
             
             # Build and start services
             docker compose pull
-            docker compose up -d
+            docker compose up --build -d
             docker system prune -f --all --volumes
             
             # Check if services are running


### PR DESCRIPTION
Modify the deployment script in the main workflow to include the `--build` flag when running `docker compose up`. This ensures that containers are rebuilt on the remote host using the latest code and Dockerfiles after pulling changes, rather than potentially reusing outdated local images.