### PR TITLE
Fix: Improve error handling for status API fetch

### DIFF
--- a/status/src/App.jsx
+++ b/status/src/App.jsx
@@ -33,13 +33,21 @@ export default function StatusDashboard() {
       setError(null);   // Clear previous errors
       try {
         const response = await fetch('/api/status-data');
+
         if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+          const errorText = await response.text(); // Read response body as text
+          throw new Error(`HTTP error! status: ${response.status}, body: ${errorText}`);
         }
-        const data = await response.json();
+
+        const contentType = response.headers.get('content-type');
+        if (!contentType || !contentType.includes('application/json')) {
+          throw new Error(`Expected application/json but received ${contentType}`);
+        }
+
+        const data = await response.json(); // Now safe to parse as JSON
         setStatusData(data);
       } catch (e) {
-        console.error("Failed to fetch status data:", e);
+        console.error("Failed to fetch status data:", e.message); // Log the more informative error
         setError(`Failed to load data: ${e.message}`);
       } finally {
         setLoading(false);


### PR DESCRIPTION
The status dashboard (`status/src/App.jsx`) was encountering a SyntaxError when the `/api/status-data` endpoint returned a non-JSON response (e.g., an error page or incomplete data).

This change improves the `fetchStatusData` function to:
1. Check `response.ok` before attempting to parse. If not ok, it throws an error including the status code and response text.
2. Check the `Content-Type` header. If it's not `application/json`, it throws an error.

This ensures `response.json()` is only called on valid JSON responses, preventing the SyntaxError and providing better error messages in case of API failures.