### PR TITLE
Fix: Route /status-data correctly in Nginx

### DIFF
--- a/config/nginx/latency.space.conf
+++ b/config/nginx/latency.space.conf
@@ -105,6 +105,39 @@ server {
     limit_req zone=ip burst=10 nodelay;
     limit_conn addr 10;
 
+    # Proxy status data requests to the backend API
+    location = /status-data {
+        proxy_pass http://172.18.0.2:80/api/status-data;
+
+        # Standard proxy headers (copy from another proxy block like /_debug/ or /api/status-data)
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_cache_bypass $http_upgrade;
+
+        # Set timeouts similar to other API endpoints
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+
+        # Add CORS headers to allow frontend access
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' '*' always;
+
+        # Handle potential OPTIONS requests for CORS preflight
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' '*';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+    }
+
     # Proxy root to the status service
     location / {
         # Explicitly exclude debug paths to ensure they're handled by the dedicated location blocks


### PR DESCRIPTION
The frontend on the main domain (latency.space) was requesting data from /status-data. However, the main Nginx configuration lacked a specific location block for this path. Requests were incorrectly falling through to the root location block, which proxied back to the status frontend service, causing it to serve index.html instead of the expected JSON data.

This change adds a dedicated `location = /status-data` block to the `latency.space` server configuration in
`config/nginx/latency.space.conf`. This block proxies requests to the correct backend API endpoint (`/api/status-data` on the Go proxy service), ensuring the frontend receives the necessary JSON data. Includes appropriate proxy headers and CORS configuration.