### PR TITLE
fix(deploy): Run update-nginx.sh during deployment

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -67,6 +67,15 @@ else
   exit 1
 fi
 
+# Update Nginx config with container IPs
+echo "Updating Nginx configuration with container IPs..."
+if sudo /opt/latency-space/deploy/update-nginx.sh; then
+  echo "Nginx configuration updated successfully."
+else
+  echo "WARNING: Failed to update Nginx configuration."
+  # Optionally add further error handling here if needed
+fi
+
 # Verify deployment
 echo "Verifying services..."
 sleep 10  # Wait for services to start


### PR DESCRIPTION
The deploy.sh script was not updating the Nginx configuration after starting the Docker containers. This meant Nginx might be using an outdated configuration with incorrect container IP addresses, leading to requests like /api/status-data being misrouted and returning HTML instead of the expected JSON from the backend proxy service.

This change modifies deploy.sh to execute update-nginx.sh after `docker compose up -d`, ensuring the Nginx configuration is dynamically generated with the correct container IPs and reloaded as part of the standard deployment process.