### PR TITLE
Fix: Handle /_debug/metrics endpoint in proxy service

### DIFF
--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -564,6 +564,8 @@ func (s *Server) handleDebugEndpoint(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/_debug/")
 
 	switch path {
+case "metrics": // Add this case
+	promhttp.Handler().ServeHTTP(w, r)
 	case "distances":
 		s.printCelestialDistances(w)
 	case "help":


### PR DESCRIPTION
The Nginx configuration proxies requests for /_debug/metrics to the Go proxy service. However, the proxy service was not handling this specific path under the /_debug/ prefix, causing it to return a 404 error.

This change modifies the handleDebugEndpoint function in proxy/src/main.go to add a case for "metrics" within the switch statement. This ensures that requests to /_debug/metrics are correctly routed to the Prometheus metrics handler (promhttp.Handler), aligning the backend service behavior with the Nginx configuration.

This allows the /_debug/metrics endpoint to function as intended, exposing the service metrics for debugging purposes.