### PR TITLE
Refactor: Use HTML template for celestial info pages

### DIFF
--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"flag"

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -328,13 +328,14 @@ func (s *Server) displayCelestialInfo(w http.ResponseWriter, name string) {
 
 	var occluded bool
 	var occluderName string
-	var occluder *CelestialObject // Changed from occludingBody to occluder for clarity
+	var occluder CelestialObject // Use struct type to match IsOccluded return type
 	targetObject, targetFound := findObjectByName(celestialObjects, name)
 	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
 
 	if targetFound && earthFound {
 		occluded, occluder = IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
-		if occluded && occluder != nil {
+		// Check if an actual occluding object was returned (Name will be non-empty)
+		if occluded && occluder.Name != "" {
 			occluderName = occluder.Name
 		}
 	} else {
@@ -751,7 +752,7 @@ func main() {
 
 	// Create and start the server
 	server := NewServer(*port, *https)
-	err := server.Start()
+	err = server.Start() // Use = instead of := as err is already declared
 	if err != nil {
 		log.Fatalf("Server error: %v", err)
 	}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -2,10 +2,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"html/template"
 	"io"
 	"log"
 	"net"
@@ -21,6 +23,9 @@ import (
 	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// Global variable to hold the parsed info page template
+var infoTemplate *template.Template
 
 // Ensure tls package is used - needed for TLS configuration
 var _ = tls.Config{}
@@ -39,6 +44,19 @@ type StatusEntry struct {
 type ApiResponse struct {
 	Timestamp time.Time              `json:"timestamp"`
 	Objects   map[string][]StatusEntry `json:"objects"` // Keyed by object type (e.g., "planets", "moons")
+}
+
+// InfoPageData holds the data needed to render the celestial body info page template
+type InfoPageData struct {
+	Name              string
+	DistanceMkm       float64 // Distance in millions of kilometers
+	LatencySec        float64 // One-way latency in seconds
+	LatencyFriendly   string  // Human-readable latency (e.g., "5 minutes")
+	RoundTripFriendly string  // Human-readable round-trip time
+	OccludedClass     string  // CSS class for occlusion status ("status-visible" or "status-occluded")
+	OccludedStatus    string  // Textual description of occlusion status
+	MoonsHTML         template.HTML // Pre-rendered HTML for the moons list (if any)
+	Domain            string  // The domain name for this body (e.g., "mars.latency.space")
 }
 
 // Server is the main latency proxy server
@@ -299,67 +317,84 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// displayCelestialInfo shows information about the celestial body
+// displayCelestialInfo renders the information page for a celestial body using the template
 func (s *Server) displayCelestialInfo(w http.ResponseWriter, name string) {
-	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(http.StatusOK)
+	// 5. Set Content-Type Header
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	distance := getCurrentDistance(name)
+	// 2. Calculate Data
+	distance := getCurrentDistance(name) // km
 	latency := CalculateLatency(distance)
 
-	fmt.Fprintf(w, "<html><head><title>%s - Latency Space</title></head><body>", name)
-	fmt.Fprintf(w, "<h1>%s</h1>", name)
-	fmt.Fprintf(w, "<p>You are simulating communications from Earth to %s.</p>", name)
-	fmt.Fprintf(w, "<p>Current distance from Earth: %.2f million km</p>", distance / 1e6)
-	fmt.Fprintf(w, "<p>One-way latency: %v</p>", latency.Round(time.Second))
-	fmt.Fprintf(w, "<p>Round-trip latency: %v</p>", 2*latency.Round(time.Second))
-
-	// --- Occlusion Check ---
+	var occluded bool
+	var occluderName string
+	var occluder *CelestialObject // Changed from occludingBody to occluder for clarity
 	targetObject, targetFound := findObjectByName(celestialObjects, name)
 	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
 
-	if !targetFound {
-		log.Printf("Error: Target celestial body '%s' not found in displayCelestialInfo.", name)
-		// Don't write error to response, just log it, as basic info is already printed
-	} else if !earthFound {
-		log.Printf("Error: Earth celestial object not found in displayCelestialInfo.")
-		// Don't write error to response, just log it
-	} else {
-		occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
-		if occluded {
-			// If occluded is true, occluder is guaranteed to be non-nil by IsOccluded
-			fmt.Fprintf(w, `<p style="color: red;">Status: Occluded by %s</p>`, occluder.Name)
-		} else {
-			fmt.Fprintf(w, `<p style="color: green;">Status: Visible</p>`)
+	if targetFound && earthFound {
+		occluded, occluder = IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+		if occluded && occluder != nil {
+			occluderName = occluder.Name
 		}
+	} else {
+		log.Printf("Warning: Could not perform occlusion check for %s (targetFound: %v, earthFound: %v)", name, targetFound, earthFound)
+		// Proceed without occlusion data if objects aren't found
 	}
-	// --- End Occlusion Check ---
-
-
-	fmt.Fprintf(w, "<h2>Usage</h2>")
-	fmt.Fprintf(w, "<p>To browse a website through %s, use one of these formats:</p>", name)
-	fmt.Fprintf(w, "<ul>")
-	fmt.Fprintf(w, "<li><code>http://%s.latency.space/http://example.com</code></li>", strings.ToLower(name))
-	fmt.Fprintf(w, "<li><code>http://example.com.%s.latency.space/</code></li>", strings.ToLower(name))
-	fmt.Fprintf(w, "<li><code>http://%s.latency.space/?url=http://example.com</code></li>", strings.ToLower(name))
-	fmt.Fprintf(w, "</ul>")
-
-	fmt.Fprintf(w, "<h2>SOCKS5 Proxy</h2>")
-	fmt.Fprintf(w, "<p>For SOCKS5 proxy access through %s:</p>", name)
-	fmt.Fprintf(w, "<pre>Host: %s.latency.space\nPort: 1080\nType: SOCKS5</pre>", strings.ToLower(name))
 
 	moons := GetMoons(name)
+
+	// 3. Populate InfoPageData
+	var moonsHTML template.HTML
 	if len(moons) > 0 {
-		fmt.Fprintf(w, "<h2>Moons</h2>")
-		fmt.Fprintf(w, "<p>%s has the following moons available:</p>", name)
-		fmt.Fprintf(w, "<ul>")
+		var htmlBuilder strings.Builder
 		for _, moon := range moons {
-			fmt.Fprintf(w, "<li><a href=\"http://%s.%s.latency.space/\">%s</a></li>", moon.Name, name, moon.Name)
+			// Construct the moon's domain (e.g., phobos.mars.latency.space)
+			// Ensure both moon and planet names are lowercase for domain consistency
+			moonDomain := fmt.Sprintf("%s.%s.latency.space", strings.ToLower(moon.Name), strings.ToLower(name))
+			// Create the list item HTML, linking to the root of the moon's proxy domain
+			htmlBuilder.WriteString(fmt.Sprintf(`<li><a href="http://%s/">%s</a></li>`, moonDomain, moon.Name))
 		}
-		fmt.Fprintf(w, "</ul>")
+		moonsHTML = template.HTML(htmlBuilder.String()) // Convert final string to template.HTML
 	}
 
-	fmt.Fprintf(w, "</body></html>")
+	data := InfoPageData{
+		Name:              name,                                        // Use the original case name for display
+		DistanceMkm:       distance / 1e6,                              // Convert km to million km
+		LatencySec:        latency.Seconds(),                           // One-way latency in seconds
+		LatencyFriendly:   latency.Round(time.Second).String(),         // Friendly one-way latency
+		RoundTripFriendly: (2 * latency).Round(time.Second).String(), // Friendly round-trip latency
+		Domain:            fmt.Sprintf("%s.latency.space", strings.ToLower(name)), // Lowercase domain
+		MoonsHTML:         moonsHTML,                                   // Assign generated HTML
+	}
+
+	// Set occlusion status and class based on calculated data
+	if occluded {
+		data.OccludedClass = "status-occluded"
+		if occluderName != "" {
+			data.OccludedStatus = fmt.Sprintf("Occluded by %s", occluderName)
+		} else {
+			data.OccludedStatus = "Occluded (Unknown Occluder)" // Fallback if occluder name is missing
+			log.Printf("Warning: Occlusion detected for %s but occluder name is empty.", name)
+		}
+	} else {
+		data.OccludedClass = "status-visible"
+		data.OccludedStatus = "Visible"
+	}
+
+	// 4. Execute Template
+	// Use the globally parsed infoTemplate
+	err := infoTemplate.Execute(w, data)
+	if err != nil {
+		// Log the error
+		log.Printf("Error executing info page template for %s: %v", name, err)
+		// Attempt to send an error to the client, but only if headers haven't been written.
+		// The template engine might have already started writing, so this might fail silently
+		// or cause a "superfluous response.WriteHeader call" log, which is acceptable here.
+		http.Error(w, "Failed to render information page", http.StatusInternalServerError)
+		return // Stop further processing
+	}
+	// Note: No need to call w.WriteHeader(http.StatusOK) as Execute does this implicitly on success.
 }
 
 // parseHostForCelestialBody extracts target URL and celestial body from request
@@ -704,6 +739,13 @@ func main() {
 	https := flag.Bool("https", true, "Enable HTTPS")
 
 	flag.Parse()
+
+	// Parse the info page template at startup
+	var err error
+	infoTemplate, err = template.ParseFiles("proxy/src/templates/info_page.html")
+	if err != nil {
+		log.Fatalf("Failed to parse info page template: %v", err)
+	}
 
 	celestialObjects = InitSolarSystemObjects()
 

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
-	"testing"
 	"strings" // Import strings for case-insensitive comparison later
+	"testing"
+	"time"
 )
 
 // Mock celestial objects for testing parseHostForCelestialBody

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -165,8 +165,8 @@ func TestParseHostForCelestialBody(t *testing.T) {
 
 // Add a separate test for findObjectByName for robustness
 func TestFindObjectByName(t *testing.T) {
-    // Use the same test data
-    originalCelestialObjects := celestialObjects
+	// Use the same test data
+	originalCelestialObjects := celestialObjects
 	celestialObjects = testCelestialObjects
 	defer func() { celestialObjects = originalCelestialObjects }()
 
@@ -209,4 +209,86 @@ func TestFindObjectByName(t *testing.T) {
             }
         })
     }
+}
+
+
+// TestDisplayCelestialInfoTemplate tests the rendering of the info page template
+func TestDisplayCelestialInfoTemplate(t *testing.T) {
+	// 1. Initialize necessary state
+	celestialObjects = InitSolarSystemObjects() // Use real data
+	if celestialObjects == nil || len(celestialObjects) == 0 {
+		t.Fatal("Failed to initialize celestialObjects")
+	}
+
+	// Ensure distance cache is populated (needed by getCurrentDistance)
+	// Use a fixed time for potentially reproducible distances, though actual values depend on the library
+	calculateDistancesFromEarth(celestialObjects, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// Parse the template (relative path from within proxy/src)
+	var err error
+	infoTemplate, err = template.ParseFiles("templates/info_page.html")
+	if err != nil {
+		t.Fatalf("Failed to parse info_page.html template: %v", err)
+	}
+
+	// 2. Create mock http.ResponseWriter
+	recorder := httptest.NewRecorder()
+
+	// 3. Create a Server instance (needed to call the method)
+	s := NewServer(80, false) // Port and HTTPS setting don't matter here
+
+	// 4. Call the function under test
+	testBodyName := "Mars"
+	s.displayCelestialInfo(recorder, testBodyName)
+
+	// 5. Assert status code
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+	}
+
+	// 6. Assert response body content
+	body := recorder.Body.String()
+
+	// Check for specific HTML elements/text
+	expectedTitle := fmt.Sprintf("<title>%s - Latency Space Proxy</title>", testBodyName)
+	if !strings.Contains(body, expectedTitle) {
+		t.Errorf("Response body does not contain expected title: %s", expectedTitle)
+	}
+
+	expectedH1 := fmt.Sprintf("<h1>%s Proxy</h1>", testBodyName)
+	if !strings.Contains(body, expectedH1) {
+		t.Errorf("Response body does not contain expected H1: %s", expectedH1)
+	}
+
+	if !strings.Contains(body, "Distance from Earth:") {
+		t.Errorf("Response body does not contain 'Distance from Earth:'")
+	}
+
+	if !strings.Contains(body, "Status:") {
+		t.Errorf("Response body does not contain 'Status:'")
+	}
+
+	// Check for expected domain in usage section
+	expectedDomain := fmt.Sprintf("<code>%s.latency.space</code>", strings.ToLower(testBodyName))
+	if !strings.Contains(body, expectedDomain) {
+		t.Errorf("Response body does not contain expected domain code block: %s", expectedDomain)
+	}
+
+	// Optionally, check for moon links if the body has moons (Mars has Phobos/Deimos)
+	if testBodyName == "Mars" {
+		if !strings.Contains(body, `<li><a href="http://phobos.mars.latency.space/">Phobos</a></li>`) {
+            t.Errorf("Response body for Mars does not contain Phobos link")
+        }
+        if !strings.Contains(body, `<li><a href="http://deimos.mars.latency.space/">Deimos</a></li>`) {
+            t.Errorf("Response body for Mars does not contain Deimos link")
+        }
+	}
+
+	// Check content type header
+	expectedContentType := "text/html; charset=utf-8"
+	actualContentType := recorder.Header().Get("Content-Type")
+	if actualContentType != expectedContentType {
+		t.Errorf("Expected Content-Type '%s', got '%s'", expectedContentType, actualContentType)
+	}
+
 }

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -221,79 +221,83 @@ func TestFindObjectByName(t *testing.T) {
 func TestDisplayCelestialInfoTemplate(t *testing.T) {
 	// 1. Initialize necessary state
 	celestialObjects = InitSolarSystemObjects() // Use real data
-	if celestialObjects == nil || len(celestialObjects) == 0 {
-		t.Fatal("Failed to initialize celestialObjects")
+	// Check if initialization succeeded using the required len(slice) > 0 pattern.
+	if len(celestialObjects) > 0 {
+		// Proceed with the test only if initialization was successful
+
+		// Ensure distance cache is populated (needed by getCurrentDistance)
+		// Use a fixed time for potentially reproducible distances, though actual values depend on the library
+		calculateDistancesFromEarth(celestialObjects, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+		// Parse the template (relative path from within proxy/src)
+		var err error
+		infoTemplate, err = template.ParseFiles("templates/info_page.html")
+		if err != nil {
+			t.Fatalf("Failed to parse info_page.html template: %v", err)
+		}
+
+		// 2. Create mock http.ResponseWriter
+		recorder := httptest.NewRecorder()
+
+		// 3. Create a Server instance (needed to call the method)
+		s := NewServer(80, false) // Port and HTTPS setting don't matter here
+
+		// 4. Call the function under test
+		testBodyName := "Mars"
+		s.displayCelestialInfo(recorder, testBodyName)
+
+		// 5. Assert status code
+		if recorder.Code != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
+		}
+
+		// 6. Assert response body content
+		body := recorder.Body.String()
+
+		// Check for specific HTML elements/text
+		expectedTitle := fmt.Sprintf("<title>%s - Latency Space Proxy</title>", testBodyName)
+		if !strings.Contains(body, expectedTitle) {
+			t.Errorf("Response body does not contain expected title: %s", expectedTitle)
+		}
+
+		expectedH1 := fmt.Sprintf("<h1>%s Proxy</h1>", testBodyName)
+		if !strings.Contains(body, expectedH1) {
+			t.Errorf("Response body does not contain expected H1: %s", expectedH1)
+		}
+
+		if !strings.Contains(body, "Distance from Earth:") {
+			t.Errorf("Response body does not contain 'Distance from Earth:'")
+		}
+
+		if !strings.Contains(body, "Status:") {
+			t.Errorf("Response body does not contain 'Status:'")
+		}
+
+		// Check for expected domain in usage section
+		expectedDomain := fmt.Sprintf("<code>%s.latency.space</code>", strings.ToLower(testBodyName))
+		if !strings.Contains(body, expectedDomain) {
+			t.Errorf("Response body does not contain expected domain code block: %s", expectedDomain)
+		}
+
+		// Optionally, check for moon links if the body has moons (Mars has Phobos/Deimos)
+		if testBodyName == "Mars" {
+			if !strings.Contains(body, `<li><a href="http://phobos.mars.latency.space/">Phobos</a></li>`) {
+				t.Errorf("Response body for Mars does not contain Phobos link")
+			}
+			if !strings.Contains(body, `<li><a href="http://deimos.mars.latency.space/">Deimos</a></li>`) {
+				t.Errorf("Response body for Mars does not contain Deimos link")
+			}
+		}
+
+		// Check content type header
+		expectedContentType := "text/html; charset=utf-8"
+		actualContentType := recorder.Header().Get("Content-Type")
+		if actualContentType != expectedContentType {
+			t.Errorf("Expected Content-Type '%s', got '%s'", expectedContentType, actualContentType)
+		}
+
+	} else {
+		// Fail the test if initialization did not produce a non-empty slice
+		t.Fatal("Failed to initialize celestialObjects (slice is nil or empty)")
 	}
-
-	// Ensure distance cache is populated (needed by getCurrentDistance)
-	// Use a fixed time for potentially reproducible distances, though actual values depend on the library
-	calculateDistancesFromEarth(celestialObjects, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-
-	// Parse the template (relative path from within proxy/src)
-	var err error
-	infoTemplate, err = template.ParseFiles("templates/info_page.html")
-	if err != nil {
-		t.Fatalf("Failed to parse info_page.html template: %v", err)
-	}
-
-	// 2. Create mock http.ResponseWriter
-	recorder := httptest.NewRecorder()
-
-	// 3. Create a Server instance (needed to call the method)
-	s := NewServer(80, false) // Port and HTTPS setting don't matter here
-
-	// 4. Call the function under test
-	testBodyName := "Mars"
-	s.displayCelestialInfo(recorder, testBodyName)
-
-	// 5. Assert status code
-	if recorder.Code != http.StatusOK {
-		t.Errorf("Expected status code %d, got %d", http.StatusOK, recorder.Code)
-	}
-
-	// 6. Assert response body content
-	body := recorder.Body.String()
-
-	// Check for specific HTML elements/text
-	expectedTitle := fmt.Sprintf("<title>%s - Latency Space Proxy</title>", testBodyName)
-	if !strings.Contains(body, expectedTitle) {
-		t.Errorf("Response body does not contain expected title: %s", expectedTitle)
-	}
-
-	expectedH1 := fmt.Sprintf("<h1>%s Proxy</h1>", testBodyName)
-	if !strings.Contains(body, expectedH1) {
-		t.Errorf("Response body does not contain expected H1: %s", expectedH1)
-	}
-
-	if !strings.Contains(body, "Distance from Earth:") {
-		t.Errorf("Response body does not contain 'Distance from Earth:'")
-	}
-
-	if !strings.Contains(body, "Status:") {
-		t.Errorf("Response body does not contain 'Status:'")
-	}
-
-	// Check for expected domain in usage section
-	expectedDomain := fmt.Sprintf("<code>%s.latency.space</code>", strings.ToLower(testBodyName))
-	if !strings.Contains(body, expectedDomain) {
-		t.Errorf("Response body does not contain expected domain code block: %s", expectedDomain)
-	}
-
-	// Optionally, check for moon links if the body has moons (Mars has Phobos/Deimos)
-	if testBodyName == "Mars" {
-		if !strings.Contains(body, `<li><a href="http://phobos.mars.latency.space/">Phobos</a></li>`) {
-            t.Errorf("Response body for Mars does not contain Phobos link")
-        }
-        if !strings.Contains(body, `<li><a href="http://deimos.mars.latency.space/">Deimos</a></li>`) {
-            t.Errorf("Response body for Mars does not contain Deimos link")
-        }
-	}
-
-	// Check content type header
-	expectedContentType := "text/html; charset=utf-8"
-	actualContentType := recorder.Header().Get("Content-Type")
-	if actualContentType != expectedContentType {
-		t.Errorf("Expected Content-Type '%s', got '%s'", expectedContentType, actualContentType)
-	}
-
 }


### PR DESCRIPTION
I replaced the direct HTML generation in `displayCelestialInfo` with the execution of the `proxy/src/templates/info_page.html` template.

This improves maintainability and separation of concerns.

- Added `html/template` and `bytes` imports.
- Added `InfoPageData` struct to hold template data.
- Parsed the template once at server startup.
- Refactored `displayCelestialInfo` to populate the struct and execute the template.
- Added a test case (`TestDisplayCelestialInfoTemplate`) to verify the template is used correctly.