### PR TITLE
Output:debugging

### DIFF
--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -600,6 +600,7 @@ func (s *Server) handleStatusData(w http.ResponseWriter, r *http.Request) {
 	// Ensure distance data is up-to-date
 	now := time.Now()
 	calculateDistancesFromEarth(celestialObjects, now) // Refresh cache
+	log.Printf("DEBUG: distanceEntries after calculation: %+v\n", distanceEntries)
 
 	// Prepare the response structure
 	response := ApiResponse{
@@ -630,7 +631,7 @@ func (s *Server) handleStatusData(w http.ResponseWriter, r *http.Request) {
 
 		// Check if the entry was found in the slice
 		if !found {
-			log.Printf("Warning: Distance entry not found for %s in handleStatusData slice lookup", obj.Name)
+			log.Printf("Warning: Failed to find distance entry for obj.Name='%s' in distanceEntries lookup. Skipping object.", obj.Name)
 			continue // Skip this object if no distance data is found
 		}
 


### PR DESCRIPTION
Okay, I've added some debug logging to the `handleStatusData` function.

This will help diagnose why objects or fields might be missing from the response in `/api/status-data` located in `proxy/src/main.go`.

Specifically, I've added logging to:
- Show the content of the `distanceEntries` slice after it's calculated.
- Provide a more specific warning when looking up an object in `distanceEntries` fails, indicating which object name was skipped.

This should help pinpoint if any issues are coming from the `calculateDistancesFromEarth` function or how `distanceEntries` is structured.