### PR TITLE
Fix(deploy): Ensure proxy container uses latest build

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -64,12 +64,12 @@ if command -v docker compose &> /dev/null; then
   # Docker Compose v2
   docker compose down
   docker compose pull
-  docker compose up -d
+  docker compose up -d --force-recreate
 elif command -v docker-compose &> /dev/null; then
   # Legacy Docker Compose
   docker-compose down
   docker-compose pull
-  docker-compose up -d
+  docker-compose up -d --force-recreate
 else
   echo "Neither docker compose nor docker-compose found. Please install Docker Compose."
   exit 1

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -63,6 +63,8 @@ docker ps -aq | xargs -r docker stop || true
 echo "🔄 Restarting all containers..."
 cd /opt/latency-space
 docker compose down
+echo "🏗️ Building proxy image..."
+docker compose build --no-cache proxy
 docker compose up -d
 if [ $? -eq 0 ]; then
   echo "✅ All containers restarted successfully"


### PR DESCRIPTION
Modified the deployment scripts:

- Added `--force-recreate` flag to `docker compose up` in `deploy.sh` to ensure containers are always recreated, using the latest image tagged 'latest'.
- Added `docker compose build --no-cache proxy` to `update.sh` to ensure manual updates rebuild the proxy image from source.

These changes address an issue where new versions of the proxy code were built but not deployed because the existing container was not properly replaced or the image wasn't rebuilt during manual updates.