### PR TITLE
feat: Enable HTTPS for subdomains in Nginx config

### DIFF
--- a/deploy/update-nginx.sh
+++ b/deploy/update-nginx.sh
@@ -173,11 +173,44 @@ server {
     }
 }
 
-# Server for all other .latency.space subdomains
+# Server block for HTTP -> HTTPS redirect for subdomains
 server {
     listen 80;
+    listen [::]:80;
     server_name ~^[^.]+\.latency\.space$ ~^[^.]+\.[^.]+\.latency\.space$ ~^[^.]+\.[^.]+\.[^.]+\.latency\.space$;
-    
+
+    # Handle Let's Encrypt validation challenges by proxying to the backend Go app
+    location /.well-known/acme-challenge/ {
+        proxy_pass http://$PROXY_IP:8080; # Target the Go app's internal HTTP port (Note: Using $PROXY_IP variable from script)
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # Redirect all other HTTP requests to HTTPS
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+
+
+# Server for all other .latency.space subdomains
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ~^[^.]+\.latency\.space$ ~^[^.]+\.[^.]+\.latency\.space$ ~^[^.]+\.[^.]+\.[^.]+\.latency\.space$;
+
+    ssl_certificate /etc/letsencrypt/live/latency.space/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/latency.space/privkey.pem;
+    # Include recommended settings from certbot/nginx guide (or similar standard practice)
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
     # Handle Let's Encrypt validation challenges by proxying to the backend Go app
     location /.well-known/acme-challenge/ {
         proxy_pass http://$PROXY_IP:8080; # Target the Go app's internal HTTP port (Note: Using $PROXY_IP variable from script)


### PR DESCRIPTION
Modified the `deploy/update-nginx.sh` script to correctly configure Nginx for HTTPS on subdomains (`*.latency.space`).

Changes:
- Added `listen 443 ssl http2;` and related SSL directives (certificates, protocols, ciphers) to the subdomain server block. Certificates are assumed to be managed by Certbot at `/etc/letsencrypt/live/latency.space/`.
- Added a separate server block listening on port 80 for subdomains to handle Let's Encrypt HTTP-01 challenges and redirect all other HTTP traffic to HTTPS using a 301 redirect.
- The backend proxy pass for subdomains remains HTTP (`http://$PROXY_IP:80;`) as the internal service might not be HTTPS-enabled.

This resolves the issue where subdomains were only served over HTTP.