### PR TITLE
Fix(deploy): Copy generated diagnostic.html to Nginx webroot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,6 +313,11 @@ jobs:
               echo "Warning: Diagnostic script issues encountered, but continuing deployment"
             fi
             
+            echo "Copying diagnostic report to Nginx root..."
+            sudo cp /tmp/latency-space/html/diagnostic.html /var/www/html/diagnostic.html
+            sudo chmod 644 /var/www/html/diagnostic.html
+            echo "Diagnostic report copied."
+            
             echo "Deployment completed successfully!"
 
       # Verify that deployment was successful


### PR DESCRIPTION
The GitHub Actions deployment workflow was correctly executing the `deploy/diagnostic.sh` script to generate a diagnostic report. However, it was missing a step to copy the generated report from `/tmp/latency-space/html/diagnostic.html` to the Nginx webroot at `/var/www/html/diagnostic.html`.

This resulted in Nginx serving an old, stale version of the report, even though a new one was being generated during each deployment.

This commit adds the necessary `cp` and `chmod` commands to the `Deploy using SSH` step in the `.github/workflows/main.yml` file to copy the report to the correct location after it's generated. This ensures the verification step in the workflow and you accessing the URL see the report from the latest deployment.