### PR TITLE
fix: Add libc-utils to container images for getent

### DIFF
--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -8,6 +8,7 @@ COPY rules/ /etc/prometheus/rules/
 
 # Set permissions but stay as root
 USER root
+RUN apk add --no-cache libc-utils
 RUN chown -R nobody:nobody /etc/prometheus /prometheus
 # Stay as root to avoid permission issues
 # USER nobody

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache \
     iproute2=~6.6 \
     iptables=~1.8 \
     openssl=~3.1 \
+    libc-utils \
     && mkdir -p /etc/latency-space
 
 # Copy the binary and templates

--- a/status/Dockerfile
+++ b/status/Dockerfile
@@ -16,6 +16,8 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 
+RUN apk add --no-cache libc-utils
+
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
The diagnostic.sh script uses `docker exec` to run `getent hosts ...` inside the proxy, status, and prometheus containers.

These containers use Alpine-based images which do not include the `getent` command by default. This resulted in "exec: "getent": executable file not found in $PATH" errors in the docker logs when the diagnostic script was run.

This change adds the `libc-utils` package (which provides `getent` on Alpine) to the Dockerfiles for the proxy, status, and prometheus services to ensure the diagnostic script can run correctly.