### PR TITLE
Fix: Ensure distinct distances are cached for spacecraft

### DIFF
--- a/proxy/src/calculations_test.go
+++ b/proxy/src/calculations_test.go
@@ -3,5 +3,98 @@
 
 package main
 
-// This file is kept for compatibility but the actual test helper functions
-// have been moved to test_helpers.go
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// TestDistinctSpacecraftDistances verifies that calculateDistancesFromEarth
+// computes different distances for spacecraft in different locations relative to Earth.
+func TestDistinctSpacecraftDistances(t *testing.T) {
+	// 1. Define Test Data (Simplified Orbital Parameters)
+	// Using simplified heliocentric coordinates (AU) for a specific time.
+	// These are NOT accurate orbital elements, just positions for testing.
+	earth := CelestialObject{
+		Name: "Earth", Type: "planet",
+		// Simplified position: 1 AU along X-axis
+		A: 1.0, E: 0, I: 0, L: 0, LP: 0, N: 0, // Simplified elements for position calc
+	}
+	// Voyager 1 - Far out in the solar system
+	voyager1 := CelestialObject{
+		Name: "Voyager 1", Type: "spacecraft", ParentName: "Sun", // Heliocentric
+		// Simplified position: ~150 AU along X-axis (very far)
+		A: 150.0, E: 0, I: 0, L: 0, LP: 0, N: 0, // Simplified elements
+		Radius: 1, // Placeholder
+	}
+	// JWST - Near Earth's L2 point (roughly 0.01 AU further from Sun than Earth)
+	jwst := CelestialObject{
+		Name: "JWST", Type: "spacecraft", ParentName: "Sun", // Heliocentric (simplified model for test)
+		// Simplified position: ~1.01 AU along X-axis
+		A: 1.01, E: 0, I: 0, L: 0, LP: 0, N: 0, // Simplified elements
+		Radius: 1, // Placeholder
+	}
+
+	testObjects := []CelestialObject{earth, voyager1, jwst}
+
+	// 2. Define a fixed time
+	testTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// 3. Call calculateDistancesFromEarth with test data
+	// This function updates the global distanceEntries slice
+	// Reset global state before test
+	distanceEntries = []DistanceEntry{}
+	lastDistanceUpdate = time.Time{}
+	// Set the global celestialObjects for the test context IF NEEDED by dependencies
+	// Since calculateDistancesFromEarth takes objects as arg, we don't strictly need this
+	// But GetObjectPosition relies on the global slice if ParentName lookups occur
+	originalCelestialObjects := celestialObjects // backup
+	celestialObjects = testObjects               // set global for GetObjectPosition
+	defer func() { celestialObjects = originalCelestialObjects }() // restore
+
+	calculateDistancesFromEarth(testObjects, testTime)
+
+	// 4. Read Results using RLock
+	DistanceCacheMutex.RLock()
+	var voyagerDist, jwstDist float64 = -1.0, -1.0 // Use -1 as sentinel for "not found"
+
+	t.Logf("Reading distanceEntries (size: %d)", len(distanceEntries)) // Log cache size
+	for _, entry := range distanceEntries {
+		t.Logf("Found entry: %s, Dist: %f", entry.Object.Name, entry.Distance) // Log each entry
+		if entry.Object.Name == "Voyager 1" {
+			voyagerDist = entry.Distance
+		} else if entry.Object.Name == "JWST" {
+			jwstDist = entry.Distance
+		}
+	}
+	DistanceCacheMutex.RUnlock()
+
+	// 5. Assert distances were found
+	if voyagerDist == -1.0 {
+		t.Fatalf("Distance for Voyager 1 not found in cache")
+	}
+	if jwstDist == -1.0 {
+		t.Fatalf("Distance for JWST not found in cache")
+	}
+	t.Logf("Voyager 1 Distance: %f km, JWST Distance: %f km", voyagerDist, jwstDist)
+
+	// 6. Assert distances are distinct
+	// Expect JWST to be much closer than Voyager 1
+	// JWST should be roughly 0.01 AU from Earth (~1.5 million km)
+	// Voyager 1 should be roughly 149 AU from Earth (~22 billion km)
+	// Check they are significantly different (e.g., > 10 million km difference)
+	if math.Abs(voyagerDist-jwstDist) < 10e6 { // 10 million km threshold
+		t.Errorf("Expected distinct distances for Voyager 1 and JWST, but got Voyager: %f km, JWST: %f km (difference < 10M km)", voyagerDist, jwstDist)
+	}
+
+	// Optional: Add approximate checks for expected ranges
+	expectedJwstDist := 0.01 * AU // ~1.5 million km
+	if math.Abs(jwstDist-expectedJwstDist) > 0.5e6 { // Allow 500k km tolerance
+		t.Errorf("JWST distance (%f km) is further than expected (%f km +/- 500k km) from Earth based on simplified model", jwstDist, expectedJwstDist)
+	}
+
+	expectedVoyagerDist := 149.0 * AU // ~22 billion km
+	if math.Abs(voyagerDist-expectedVoyagerDist) > 1e9 { // Allow 1 billion km tolerance (large distance)
+		t.Errorf("Voyager 1 distance (%f km) significantly different than expected (%f km +/- 1B km) from Earth based on simplified model", voyagerDist, expectedVoyagerDist)
+	}
+}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -616,11 +616,12 @@ func (s *Server) printCelestialDistances(w http.ResponseWriter) {
 	fmt.Fprintln(w, "============================================")
 	fmt.Fprintf(w, "Current Time: %s\n\n", time.Now().Format(time.RFC3339))
 
-	printObjectsByType(w, distanceEntries, "planet")
-	printObjectsByType(w, distanceEntries, "moon")
-	printObjectsByType(w, distanceEntries, "asteroid")
-	printObjectsByType(w, distanceEntries, "dwarf_planet")
-	printObjectsByType(w, distanceEntries, "spacecraft")
+	// Call printObjectsByType without distanceEntries argument, as it now uses the global cache
+	printObjectsByType(w, "planet")
+	printObjectsByType(w, "moon")
+	printObjectsByType(w, "asteroid")
+	printObjectsByType(w, "dwarf_planet")
+	printObjectsByType(w, "spacecraft")
 
 }
 


### PR DESCRIPTION
Previously, the landing page showed identical distance and latency data for most spacecraft, except Mars Perseverance. This was likely caused by a race condition when updating the global distance cache (`distanceEntries` in proxy/src/calculations.go) if multiple requests triggered a cache refresh simultaneously.

This commit introduces a `sync.RWMutex` (`DistanceCacheMutex`) to protect reads and writes to `distanceEntries` and `lastDistanceUpdate`. The `calculateDistancesFromEarth` function now uses a double-check locking pattern to ensure only one goroutine updates the cache upon expiry. Functions reading the cache (`getCurrentDistance`, `printObjectsByType`, `handleStatusData`) now use read locks.

Additionally, a unit test `TestDistinctSpacecraftDistances` was added to `proxy/src/calculations_test.go` to verify that distinct distances are calculated and retrieved for different spacecraft using the updated caching mechanism.