### PR TITLE
Fix: Correct distance calculation for spacecraft

### DIFF
--- a/proxy/src/go.mod
+++ b/proxy/src/go.mod
@@ -3,11 +3,10 @@ module github.com/latency-space/proxy
 go 1.21
 
 require github.com/latency-space/shared v0.0.0
+
 require (
-	github.com/gorilla/websocket v1.5.3
 	github.com/prometheus/client_golang v1.20.5
 	golang.org/x/crypto v0.29.0
-	golang.org/x/time v0.8.0
 )
 
 require (

--- a/proxy/src/go.sum
+++ b/proxy/src/go.sum
@@ -4,8 +4,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -28,7 +26,5 @@ golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.20.0 h1:gK/Kv2otX8gz+wn7Rmb3vT96ZwuoxnQlY+HlJVj7Qug=
 golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=
-golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
-golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=


### PR DESCRIPTION
This commit addresses an issue where spacecraft, particularly those orbiting the Sun (heliocentric), could report incorrect, often near-zero, distances.

The root causes were twofold:
1. The global `celestialObjects` slice in `proxy/src/calculations.go` was not being initialized with data from `shared/celestial/celestial.go`.
2. A unit conversion error in `GetObjectPosition`: The position of a spacecraft relative to its parent (`localPos`) was unconditionally converted from km to AU. This was incorrect for heliocentric spacecraft, as their `localPos` (calculated via `calculateLocalPosition`) is already in AU because their semi-major axis (`A`) is defined in AU. This resulted in their AU positions being divided by the AU constant again.

Changes made:
- Added an `init()` function in `proxy/src/calculations.go` to initialize the global `celestialObjects` with `celestial.InitSolarSystemObjects()`.
- Updated `proxy/src/calculations.go` to use the `CelestialObject` type, `Vector3` type, and astronomical constants (AU, SPEED_OF_LIGHT, etc.) from the `shared/celestial` package for consistency.
- Modified the conditional logic in `GetObjectPosition`. The km-to-AU conversion for `localPos` is now correctly applied only to moons and to spacecraft whose `ParentName` is not "Sun" (i.e., those whose semi-major axis `A` is defined in km). Heliocentric spacecraft retain their `localPos` in AU.

The existing test `TestDistinctSpacecraftDistances` validates the fix for heliocentric spacecraft, as it uses test objects with `ParentName: "Sun"` and semi-major axes defined in AU. These tests pass with the corrected logic.