### PR TITLE
Fix: Improve proxy timeout handling for robustness (revised)

### DIFF
--- a/config/nginx/minimal.conf
+++ b/config/nginx/minimal.conf
@@ -137,5 +137,9 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Destination $host;
         proxy_cache_bypass $http_upgrade;
+        
+        proxy_connect_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_read_timeout 86400s;
     }
 }

--- a/deploy/update-nginx.sh
+++ b/deploy/update-nginx.sh
@@ -273,9 +273,9 @@ server {
         proxy_cache_bypass \$http_upgrade;
         
         # Set timeouts to prevent hanging connections
-        proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_connect_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_read_timeout 86400s;
     }
     
     # Return 444 (no response) for suspicious requests

--- a/proxy/src/socks.go
+++ b/proxy/src/socks.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"os"
 )
 
 // SOCKS constants
@@ -44,6 +45,8 @@ const (
 	SOCKS5_REP_CMD_NOT_SUPPORTED   = 0x07
 	SOCKS5_REP_ADDR_NOT_SUPPORTED  = 0x08
 )
+
+const readWriteBufferTime = 30 * time.Second
 
 // SOCKSHandler handles SOCKS protocol connections
 type SOCKSHandler struct {
@@ -336,11 +339,22 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 	// Client -> Target with celestial body latency
 	go func() {
 		defer wg.Done()
+		defer target.Close() // Ensure target is closed when this goroutine exits
+		defer s.conn.Close() // Ensure client conn is closed when this goroutine exits
+
 		buf := make([]byte, 32*1024)
 		for {
+			deadline := time.Now().Add(latency*2 + readWriteBufferTime)
+			if err := s.conn.SetReadDeadline(deadline); err != nil {
+				log.Printf("Error setting read deadline for client: %v", err)
+				break
+			}
+
 			n, err := s.conn.Read(buf)
 			if err != nil {
-				if err != io.EOF {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					log.Printf("Timeout reading from client: %v", err)
+				} else if err != io.EOF {
 					log.Printf("Error reading from client: %v", err)
 				}
 				break
@@ -358,17 +372,27 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 				break
 			}
 		}
-		target.Close()
 	}()
 
 	// Target -> Client with celestial body latency
 	go func() {
 		defer wg.Done()
+		defer s.conn.Close() // Ensure client conn is closed when this goroutine exits
+		defer target.Close() // Ensure target is closed when this goroutine exits
+
 		buf := make([]byte, 32*1024)
 		for {
+			deadline := time.Now().Add(latency*2 + readWriteBufferTime)
+			if err := target.SetReadDeadline(deadline); err != nil {
+				log.Printf("Error setting read deadline for target: %v", err)
+				break
+			}
+
 			n, err := target.Read(buf)
 			if err != nil {
-				if err != io.EOF {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					log.Printf("Timeout reading from target: %v", err)
+				} else if err != io.EOF {
 					log.Printf("Error reading from target: %v", err)
 				}
 				break
@@ -386,7 +410,6 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 				break
 			}
 		}
-		s.conn.Close()
 	}()
 
 	// Wait for both goroutines to complete


### PR DESCRIPTION
This commit addresses timeout configurations to enhance the proxy's reliability and functionality:

1. SOCKS TCP Data Transfer Timeouts:
   - I modified `proxy/src/socks.go` to set read deadlines on TCP connections during the data relay phase of SOCKS CONNECT.
   - The deadline is calculated as `one_way_latency * 2 + 30_seconds_buffer`.
   - This prevents connections from hanging indefinitely if a peer (client or target server) becomes unresponsive.
   - Timeout errors are now specifically logged.

2. Nginx HTTP Proxy Timeouts:
   - I modified `deploy/update-nginx.sh` which programmatically generates the Nginx configuration.
   - For the server block handling general subdomains (e.g., *.latency.space), the script now sets:
     - `proxy_connect_timeout 86400s`
     - `proxy_send_timeout 86400s` - `proxy_read_timeout 86400s`
   - This change ensures that the dynamically generated Nginx configuration allows for very long timeouts, accommodating the Go proxy's intentional latency simulation for distant celestial bodies.

These changes ensure that timeouts are comprehensively applied and are set to at least "latency * 2" where appropriate, making the proxy more robust and fully functional under varying latency conditions.