### PR TITLE
fix: Allow individual container startup diagnostics to complete witho…

### DIFF
--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -305,8 +305,8 @@ elif [ "$RUNNING" -lt "$TOTAL" ]; then
     echo ""
     blue "=== Trying to start $service ==="
 
-    # Capture full error output
-    STARTUP_OUTPUT=$(docker compose up -d $service 2>&1)
+    # Capture full error output (allow failure with || true to continue diagnostics)
+    STARTUP_OUTPUT=$(docker compose up -d $service 2>&1 || true)
     echo "$STARTUP_OUTPUT"
 
     # Try to get more details from Docker events


### PR DESCRIPTION
…ut script exit

Final fix for set -e issue: when trying to start failed containers individually for diagnostics, the script was exiting on first failure instead of capturing the error message.

Added || true to the command substitution for STARTUP_OUTPUT so the script continues through all failed containers and shows detailed port conflict information for each one.