### PR TITLE
Fix HTTP proxy, SOCKS throughput, and add abuse controls

### DIFF
--- a/deploy/update-nginx.sh
+++ b/deploy/update-nginx.sh
@@ -271,13 +271,18 @@ server {
         proxy_set_header X-Forwarded-For \$remote_addr;
         proxy_set_header X-Destination \$host;
         proxy_cache_bypass \$http_upgrade;
-        
-        # Set timeouts to prevent hanging connections
+
+        # The Go proxy deliberately delays responses by interplanetary
+        # light-travel time. A 60s cap here 504'd every body past ~30s
+        # one-way (i.e. most of them at real distance) regardless of what
+        # the proxy did. Sized for distant bodies; buffering off so the
+        # delayed response streams straight through.
         proxy_connect_timeout 10s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
     }
-    
+
     # Return 444 (no response) for suspicious requests
     location ~ \.(php|aspx|asp|cgi|jsp)$ {
         return 444;

--- a/deploy/vps-maintenance-setup.sh
+++ b/deploy/vps-maintenance-setup.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# One-time setup: disk-cleanup + cert-reload automation for latency.space.
+# Root cause of the 2026 outage: 25GB of Docker build cache filled the disk,
+# so no containers could start (nginx then returned 502). Plus certbot renewed
+# the cert but nginx was never reloaded, so an expired cert was served.
+set -uo pipefail
+
+echo "== 1. Weekly Docker cleanup cron =="
+cat > /etc/cron.d/docker-cleanup <<'CRON'
+# Weekly Docker cleanup - prevents build-cache disk exhaustion.
+# Prunes build cache unused >7 days and dangling images. Named volumes untouched.
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+30 4 * * 0 root docker builder prune -f --filter until=168h >> /var/log/docker-cleanup.log 2>&1; docker image prune -f >> /var/log/docker-cleanup.log 2>&1
+CRON
+chmod 644 /etc/cron.d/docker-cleanup
+echo "   -> /etc/cron.d/docker-cleanup"
+
+echo "== 2. BuildKit GC cap in daemon.json (auto-limit; applies on next docker restart) =="
+cp -a /etc/docker/daemon.json "/etc/docker/daemon.json.bak.$(date +%s)"
+tmp=$(mktemp)
+if jq '. + {builder: {gc: {enabled: true, defaultKeepStorage: "10GB"}}}' /etc/docker/daemon.json > "$tmp" && jq empty "$tmp" 2>/dev/null; then
+  mv "$tmp" /etc/docker/daemon.json
+  echo "   -> merged builder.gc (cap 10GB). NOT restarting docker; effective on next restart."
+else
+  echo "   -> ERROR merging daemon.json; original kept."; rm -f "$tmp"
+fi
+
+echo "== 3. certbot deploy-hook: reload nginx on every renewal =="
+mkdir -p /etc/letsencrypt/renewal-hooks/deploy
+cat > /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh <<'HOOK'
+#!/bin/sh
+# Runs after any successful certbot renewal so the new cert is actually served.
+systemctl reload nginx
+HOOK
+chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
+echo "   -> /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh"
+
+echo "== 4. Weekly safety nginx reload cron =="
+cat > /etc/cron.d/nginx-cert-reload <<'CRON'
+# Weekly graceful nginx reload so a renewed cert never drifts unserved.
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+15 3 * * 1 root systemctl reload nginx >> /var/log/nginx-cert-reload.log 2>&1
+CRON
+chmod 644 /etc/cron.d/nginx-cert-reload
+echo "   -> /etc/cron.d/nginx-cert-reload"
+
+echo "== 5. Reload nginx now (serve the already-renewed cert) =="
+if nginx -t 2>/tmp/nginxtest; then
+  systemctl reload nginx && echo "   -> nginx reloaded OK"
+else
+  echo "   -> nginx config test FAILED, not reloading:"; cat /tmp/nginxtest
+fi
+echo "== done =="

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,7 +296,15 @@ networks:
     ipam:
       driver: default
       config:
+        # ip_range confines DYNAMIC address allocation to .128/25. The core
+        # services below pin static IPs 172.18.0.2-.5, which sit OUTSIDE this
+        # range. Without ip_range, the many socks-* containers (no static IP)
+        # get dynamic addresses starting at .2 and steal the static ones,
+        # causing "Address already in use" for proxy/status/prometheus/grafana
+        # on a full `docker compose up`. Keeping dynamic and static apart makes
+        # restarts and deploys order-independent.
         - subnet: "172.18.0.0/16"
+          ip_range: "172.18.0.128/25"
           gateway: "172.18.0.1"
 
 volumes:

--- a/proxy/src/delay.go
+++ b/proxy/src/delay.go
@@ -1,0 +1,89 @@
+// proxy/src/delay.go
+//
+// Latency simulation primitives. Light-speed delay shifts every byte in time
+// by a constant; it does not reduce throughput. The old SOCKS relay slept one
+// full one-way latency per 32KB chunk, so a Mars link (~12 min one-way)
+// carried roughly 45 bytes/s and a TLS handshake could take over an hour.
+// delayCopy instead timestamps chunks as they arrive and releases each one
+// exactly `latency` later: throughput is preserved while every byte still
+// arrives late by the light-travel time.
+package main
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+const (
+	delayChunkSize = 32 * 1024
+	// delayQueueLen bounds buffered in-flight data per direction
+	// (delayQueueLen * delayChunkSize = 512KB). When the queue is full the
+	// reader stalls, which acts as crude bandwidth backpressure.
+	delayQueueLen = 16
+)
+
+type timedChunk struct {
+	data      []byte
+	deliverAt time.Time
+}
+
+// delayCopy copies src to dst, delaying each chunk by latency. onBytes, if
+// non-nil, is called with the size of each chunk written (for metrics).
+// Returns the first error from either side; io.EOF is reported as nil.
+func delayCopy(ctx context.Context, dst io.Writer, src io.Reader, latency time.Duration, onBytes func(int)) error {
+	queue := make(chan timedChunk, delayQueueLen)
+	readErr := make(chan error, 1)
+
+	go func() {
+		defer close(queue)
+		for {
+			buf := make([]byte, delayChunkSize)
+			n, err := src.Read(buf)
+			if n > 0 {
+				select {
+				case queue <- timedChunk{data: buf[:n], deliverAt: time.Now().Add(latency)}:
+				case <-ctx.Done():
+					readErr <- ctx.Err()
+					return
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					readErr <- nil
+				} else {
+					readErr <- err
+				}
+				return
+			}
+		}
+	}()
+
+	for chunk := range queue {
+		if err := sleepCtx(ctx, time.Until(chunk.deliverAt)); err != nil {
+			return err
+		}
+		if _, err := dst.Write(chunk.data); err != nil {
+			return err
+		}
+		if onBytes != nil {
+			onBytes(len(chunk.data))
+		}
+	}
+	return <-readErr
+}
+
+// sleepCtx sleeps for d but aborts early if ctx is cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/proxy/src/delay_test.go
+++ b/proxy/src/delay_test.go
@@ -1,0 +1,84 @@
+// proxy/src/delay_test.go
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+// TestDelayCopyShiftsButDoesNotThrottle is the core throughput regression:
+// the delay line must shift the whole stream by one latency, NOT sleep once
+// per chunk (which the old relay did, throttling throughput to chunk/latency).
+func TestDelayCopyShiftsButDoesNotThrottle(t *testing.T) {
+	latency := 100 * time.Millisecond
+	payload := bytes.Repeat([]byte("x"), 256*1024) // 8 chunks of 32KB
+
+	var out bytes.Buffer
+	start := time.Now()
+	err := delayCopy(context.Background(), &out, bytes.NewReader(payload), latency, nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("delayCopy: %v", err)
+	}
+	if out.Len() != len(payload) {
+		t.Fatalf("copied %d bytes, want %d", out.Len(), len(payload))
+	}
+	if elapsed < latency {
+		t.Errorf("finished in %v, expected at least the %v delay", elapsed, latency)
+	}
+	// Old behavior: 8 chunks * 100ms = 800ms minimum. Delay-line behavior:
+	// one 100ms shift for the whole stream.
+	if elapsed > latency+200*time.Millisecond {
+		t.Errorf("took %v: per-chunk sleeping detected, expected about %v total", elapsed, latency)
+	}
+}
+
+// TestDelayCopyCancellation ensures a cancelled context tears the copy down
+// promptly instead of holding the full (possibly interplanetary) delay.
+func TestDelayCopyCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pr, pw := io.Pipe()
+	defer pw.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		var out bytes.Buffer
+		done <- delayCopy(ctx, &out, pr, time.Hour, nil)
+	}()
+
+	if _, err := pw.Write([]byte("stranded in transit")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected context error, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("delayCopy did not return after cancellation")
+	}
+}
+
+// TestDelayCopyMetricsCallback checks onBytes is invoked with the full byte
+// count (the relay uses it for bandwidth metrics).
+func TestDelayCopyMetricsCallback(t *testing.T) {
+	payload := bytes.Repeat([]byte("y"), 100*1024)
+	var counted int
+	var out bytes.Buffer
+	err := delayCopy(context.Background(), &out, bytes.NewReader(payload), time.Millisecond, func(n int) {
+		counted += n
+	})
+	if err != nil {
+		t.Fatalf("delayCopy: %v", err)
+	}
+	if counted != len(payload) {
+		t.Errorf("onBytes counted %d, want %d", counted, len(payload))
+	}
+}

--- a/proxy/src/http_proxy_test.go
+++ b/proxy/src/http_proxy_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestServer builds a Server without NewServer, which registers global
+// Prometheus metrics and therefore may only be called once per test binary.
+func newTestServer() *Server {
+	return &Server{
+		security:    NewSecurityValidator(),
+		metrics:     NewTestMetricsCollector(),
+		httpEnabled: true,
+	}
+}
+
+// TestValidateDestinationSchemeAndAllowlist covers the mechanism the HTTP
+// proxy fix relies on: ValidateDestination prepends a scheme to a bare host
+// (the raw target from parseHostForCelestialBody has none, which used to make
+// http.NewRequest fail with "unsupported protocol scheme") and enforces the
+// allowlist.
+func TestValidateDestinationSchemeAndAllowlist(t *testing.T) {
+	s := NewSecurityValidator()
+
+	// Bare allowlisted host: scheme prepended, allowed.
+	got, err := s.ValidateDestination("www.example.com")
+	if err != nil {
+		t.Fatalf("allowlisted host rejected: %v", err)
+	}
+	if got != "http://www.example.com" {
+		t.Errorf("expected scheme prepended, got %q", got)
+	}
+
+	// Non-allowlisted host: rejected (this is what keeps the HTTP path from
+	// being an open proxy).
+	if _, err := s.ValidateDestination("evil.not-listed-anywhere.example"); err == nil {
+		t.Error("expected non-allowlisted host to be rejected")
+	}
+}
+
+// TestHTTPProxyRejectsNonAllowlistedHost verifies the handler now enforces the
+// allowlist on the HTTP proxy path (previously it had no check at all, so any
+// host embedded in the subdomain was proxied — an open HTTP proxy).
+func TestHTTPProxyRejectsNonAllowlistedHost(t *testing.T) {
+	orig := celestialObjects
+	celestialObjects = []CelestialObject{
+		{Name: "Earth", Type: "planet"},
+		{Name: "Mars", Type: "planet"},
+	}
+	defer func() { celestialObjects = orig }()
+
+	s := newTestServer()
+
+	req := httptest.NewRequest("GET", "http://x/", nil)
+	req.Host = "evil.not-listed-anywhere.example.mars.latency.space"
+	rec := httptest.NewRecorder()
+
+	s.handleHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-allowlisted target, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHTTPProxyAllowlistedHostPassesValidation verifies an allowlisted target
+// is NOT rejected by validation. In test mode latency is a few ms, so the
+// handler's own "insufficient latency" guard (>=1s) returns 400 before any
+// network fetch — which is exactly the point where we can confirm validation
+// (scheme prepend + allowlist) succeeded without making a real request.
+func TestHTTPProxyAllowlistedHostPassesValidation(t *testing.T) {
+	orig := celestialObjects
+	celestialObjects = []CelestialObject{
+		{Name: "Earth", Type: "planet"},
+		{Name: "Mars", Type: "planet"},
+	}
+	defer func() { celestialObjects = orig }()
+
+	cleanup := setupTestModeWithLatency(3 * time.Millisecond)
+	defer cleanup()
+
+	s := newTestServer()
+
+	req := httptest.NewRequest("GET", "http://x/", nil)
+	req.Host = "example.com.mars.latency.space"
+	rec := httptest.NewRecorder()
+
+	s.handleHTTP(rec, req)
+
+	// Must NOT be 403 (validation passed) and must NOT be a scheme error.
+	// It stops at the insufficient-latency guard (400) before the fetch.
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("allowlisted target wrongly rejected by validation: %s", rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "unsupported protocol scheme") || strings.Contains(body, "Error creating proxy request") {
+		t.Fatalf("scheme bug still present: %s", body)
+	}
+}
+
+// TestHTTPTimeoutNoOverflow is the regression test for the Duration overflow:
+// `latency * 2 * time.Second` (Duration*Duration) went negative for distant
+// bodies. The corrected form (2*latency + 30s) must stay positive even at
+// Voyager scale.
+func TestHTTPTimeoutNoOverflow(t *testing.T) {
+	cases := []struct {
+		name    string
+		latency time.Duration
+	}{
+		{"Mars far", 22 * time.Minute},
+		{"Jupiter", 53 * time.Minute},
+		{"Voyager 1", 23 * time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			timeout := 2*tc.latency + 30*time.Second
+			if timeout <= 0 {
+				t.Errorf("timeout overflowed for %s: %v", tc.name, timeout)
+			}
+		})
+	}
+}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -61,6 +61,7 @@ type Server struct {
 	https              bool // Flag indicating whether to enable HTTPS
 	metrics            *MetricsCollector
 	security           *SecurityValidator
+	limiter            *RateLimiter // Per-IP rate/concurrency abuse controls
 	httpServer         *http.Server
 	httpsServer        *http.Server
 	socksListener      net.Listener // Listener for the SOCKS5 server
@@ -76,10 +77,19 @@ func NewServer(port int, useHTTPS bool, httpEn bool, socksEn bool, fixedBody str
 		https:              useHTTPS,
 		metrics:            NewMetricsCollector(),
 		security:           NewSecurityValidator(),
+		limiter:            newRateLimiterFromEnv(),
 		httpEnabled:        httpEn,
 		socksEnabled:       socksEn,
 		fixedCelestialBody: fixedBody,
 	}
+}
+
+// clientIP extracts the bare IP (no port) from a net.Addr string.
+func clientIP(remoteAddr string) string {
+	if idx := strings.LastIndex(remoteAddr, ":"); idx > 0 {
+		return remoteAddr[:idx]
+	}
+	return remoteAddr
 }
 
 // Start initializes and runs the HTTP, HTTPS (if enabled), and SOCKS5 servers.
@@ -88,6 +98,11 @@ func (s *Server) Start() error {
 	// Channel to listen for OS shutdown signals
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	// Background janitor to prune idle rate-limiter buckets
+	stopCleanup := make(chan struct{})
+	defer close(stopCleanup)
+	go s.limiter.StartCleanup(stopCleanup)
 
 	// Use a WaitGroup to wait for server goroutines to finish
 	var wg sync.WaitGroup
@@ -231,6 +246,20 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate and normalize the destination BEFORE doing any latency work.
+	// ValidateDestination prepends a scheme if missing (the raw targetURL
+	// from parseHostForCelestialBody has none, which made http.NewRequest
+	// fail with "unsupported protocol scheme") and enforces the same
+	// allowlist/port policy the SOCKS path uses, so the HTTP path is not an
+	// open proxy to arbitrary hosts.
+	validatedURL, err := s.security.ValidateDestination(targetURL)
+	if err != nil {
+		log.Printf("HTTP destination rejected: %s via %s: %v", targetURL, bodyName, err)
+		http.Error(w, fmt.Sprintf("Destination not allowed: %v", err), http.StatusForbidden)
+		return
+	}
+	targetURL = validatedURL
+
 	// Find the target and Earth objects
 	targetObject, targetFound := findObjectByName(celestialObjects, bodyName)
 	if !targetFound {
@@ -268,6 +297,16 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Abuse control: per-IP rate and concurrency limits. Applied here (not
+	// in nginx) because SOCKS and direct hits bypass the front-end proxy.
+	release, err := s.limiter.Acquire(clientIP(r.RemoteAddr))
+	if err != nil {
+		log.Printf("HTTP request from %s rejected: %v", r.RemoteAddr, err)
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+		return
+	}
+	defer release()
+
 	log.Printf("Proxy request for %s via %s (latency: %v)", targetURL, bodyName, latency)
 	time.Sleep(latency)
 
@@ -280,12 +319,18 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	// Apply bandwidth limiting
 	r.Header.Set("X-Celestial-Body", bodyName)
 
-	// Forward the request to the target URL
+	// Forward the request to the target URL.
+	// NB: the timeout must be derived from latency by ADDITION. The old
+	// `latency * 2 * time.Second` multiplied a Duration by a Duration
+	// (nanoseconds x 1e9), which overflowed int64 for distant bodies and
+	// produced negative timeouts (instant failure) depending on orbital
+	// position.
+	clientTimeout := 2*latency + 30*time.Second
 	client := &http.Client{
-		Timeout: latency * 2 * time.Second,
+		Timeout: clientTimeout,
 		Transport: &http.Transport{
 			MaxIdleConns:    10,
-			IdleConnTimeout: latency * 2 * time.Second,
+			IdleConnTimeout: clientTimeout,
 		},
 	}
 
@@ -511,15 +556,16 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 }
 
 func (s *Server) startHTTPServer() error {
+	addr := fmt.Sprintf(":%d", s.port)
 	s.httpServer = &http.Server{
-		Addr:         ":80",
+		Addr:         addr,
 		Handler:      http.HandlerFunc(s.handleHTTP),
 		ReadTimeout:  60 * time.Minute,  // Increased for distant celestial bodies
 		WriteTimeout: 60 * time.Minute,  // Increased for distant celestial bodies
 		IdleTimeout:  120 * time.Minute, // Allow long-lived connections
 	}
 
-	log.Printf("Starting HTTP server on :80")
+	log.Printf("Starting HTTP server on %s", addr)
 	err := s.httpServer.ListenAndServe()
 	log.Printf("HTTP server stopped: %v", err) // This will tell you if the server stops
 	return err
@@ -589,21 +635,28 @@ func (s *Server) startSOCKSServer() error {
 		}
 
 		// Get client IP for rate limiting
-		clientIP := conn.RemoteAddr().String()
-		if idx := strings.Index(clientIP, ":"); idx > 0 {
-			clientIP = clientIP[:idx]
+		ip := clientIP(conn.RemoteAddr().String())
+
+		if !s.security.IsAllowedIP(ip) {
+			conn.Close()
+			continue
 		}
 
-		// Apply rate limiting based on IP (simplified)
-		// This is a basic form of rate limiting to prevent abuse
-		if !s.security.IsAllowedIP(clientIP) {
+		// Abuse control: per-IP rate and concurrency limits. SOCKS bypasses
+		// the front-end nginx, so this is the only such control on this path.
+		release, err := s.limiter.Acquire(ip)
+		if err != nil {
+			log.Printf("SOCKS connection from %s rejected: %v", ip, err)
 			conn.Close()
 			continue
 		}
 
 		// Handle the connection in a goroutine
 		// Pass the fixed celestial body if configured
-		go NewSOCKSHandler(conn, s.security, s.metrics, s.fixedCelestialBody).Handle()
+		go func() {
+			defer release()
+			NewSOCKSHandler(conn, s.security, s.metrics, s.fixedCelestialBody).Handle()
+		}()
 	}
 }
 

--- a/proxy/src/ratelimit.go
+++ b/proxy/src/ratelimit.go
@@ -1,0 +1,184 @@
+// proxy/src/ratelimit.go
+//
+// Abuse controls for the proxy paths. The SOCKS listener listens on its own
+// port and is NOT behind the front-end nginx, so nginx's limit_req/limit_conn
+// rules never see it. The allowlist (security.go) stops the proxy being used
+// to reach arbitrary hosts, but does nothing against connection floods or an
+// attacker holding many latency-delayed tunnels open (each tunnel keeps a
+// goroutine plus a buffered delay queue alive for the full light-travel time).
+// These limits bound that.
+//
+// Two things are bounded per client IP:
+//   - new connections per minute (a token bucket), and
+//   - concurrent in-flight proxied connections (also globally).
+//
+// A small hand-rolled token bucket is used deliberately so this needs no
+// external dependency.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// limiterIdleTTL is how long an idle per-IP bucket is kept before the janitor
+// prunes it. Long enough that a client cannot reset its rate by reconnecting.
+const limiterIdleTTL = 15 * time.Minute
+
+type ipBucket struct {
+	tokens     float64
+	lastRefill time.Time
+	lastSeen   time.Time
+}
+
+// RateLimiter enforces per-IP connection rate and concurrency caps.
+// A nil *RateLimiter is a valid no-op limiter (admits everything).
+type RateLimiter struct {
+	ratePerSec float64 // token refill rate; <=0 disables the rate check
+	burst      float64
+	maxPerIP   int // <=0 disables
+	maxTotal   int // <=0 disables
+
+	mu      sync.Mutex
+	buckets map[string]*ipBucket
+	perIP   map[string]int
+	total   int
+}
+
+// NewRateLimiter builds a limiter. Zero/negative caps disable the matching
+// check, which tests and trusted deployments can rely on.
+func NewRateLimiter(connRatePerMin float64, burst, maxPerIP, maxTotal int) *RateLimiter {
+	return &RateLimiter{
+		ratePerSec: connRatePerMin / 60.0,
+		burst:      float64(burst),
+		maxPerIP:   maxPerIP,
+		maxTotal:   maxTotal,
+		buckets:    make(map[string]*ipBucket),
+		perIP:      make(map[string]int),
+	}
+}
+
+// newRateLimiterFromEnv reads the abuse-control settings from the environment,
+// falling back to sensible defaults.
+func newRateLimiterFromEnv() *RateLimiter {
+	return NewRateLimiter(
+		envFloat("CONN_RATE_PER_MIN", 60),
+		envInt("CONN_BURST", 20),
+		envInt("MAX_CONNS_PER_IP", 20),
+		envInt("MAX_CONNS_TOTAL", 500),
+	)
+}
+
+// Acquire admits a new proxied connection from ip. On success it returns a
+// release function that MUST be called when the connection finishes. On
+// rejection it returns an error naming the limit that was hit.
+func (r *RateLimiter) Acquire(ip string) (func(), error) {
+	if r == nil {
+		return func() {}, nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+
+	// Connection-rate token bucket (skipped when rate <= 0). Retained across
+	// connection close (pruned only by the janitor) so reconnecting cannot
+	// reset the rate.
+	if r.ratePerSec > 0 {
+		b, ok := r.buckets[ip]
+		if !ok {
+			b = &ipBucket{tokens: r.burst, lastRefill: now}
+			r.buckets[ip] = b
+		}
+		elapsed := now.Sub(b.lastRefill).Seconds()
+		b.tokens += elapsed * r.ratePerSec
+		if b.tokens > r.burst {
+			b.tokens = r.burst
+		}
+		b.lastRefill = now
+		b.lastSeen = now
+		if b.tokens < 1 {
+			return nil, fmt.Errorf("connection rate limit exceeded for %s", ip)
+		}
+		b.tokens--
+	}
+
+	if r.maxTotal > 0 && r.total >= r.maxTotal {
+		return nil, fmt.Errorf("server connection limit reached (%d)", r.maxTotal)
+	}
+	if r.maxPerIP > 0 && r.perIP[ip] >= r.maxPerIP {
+		return nil, fmt.Errorf("per-IP connection limit reached for %s (%d)", ip, r.maxPerIP)
+	}
+
+	r.perIP[ip]++
+	r.total++
+
+	released := false
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if released {
+			return
+		}
+		released = true
+		r.total--
+		if r.perIP[ip]--; r.perIP[ip] <= 0 {
+			delete(r.perIP, ip)
+			// The rate bucket is intentionally NOT deleted here; the janitor
+			// prunes it once genuinely idle.
+		}
+	}, nil
+}
+
+// StartCleanup runs a background janitor that prunes idle per-IP buckets until
+// stop is closed. Call once from the server; tests may omit it.
+func (r *RateLimiter) StartCleanup(stop <-chan struct{}) {
+	if r == nil {
+		return
+	}
+	ticker := time.NewTicker(limiterIdleTTL)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			r.prune()
+		}
+	}
+}
+
+func (r *RateLimiter) prune() {
+	cutoff := time.Now().Add(-limiterIdleTTL)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for ip, b := range r.buckets {
+		if r.perIP[ip] == 0 && b.lastSeen.Before(cutoff) {
+			delete(r.buckets, ip)
+		}
+	}
+}
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+		log.Printf("Ignoring invalid %s=%q", name, os.Getenv(name))
+	}
+	return def
+}
+
+func envFloat(name string, def float64) float64 {
+	if v := os.Getenv(name); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
+			return f
+		}
+		log.Printf("Ignoring invalid %s=%q", name, os.Getenv(name))
+	}
+	return def
+}

--- a/proxy/src/ratelimit_test.go
+++ b/proxy/src/ratelimit_test.go
@@ -1,0 +1,75 @@
+// proxy/src/ratelimit_test.go
+package main
+
+import "testing"
+
+func TestRateLimiterPerIPConcurrency(t *testing.T) {
+	rl := NewRateLimiter(0 /* rate disabled */, 0, 2 /* maxPerIP */, 100)
+
+	r1, err := rl.Acquire("1.2.3.4")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if _, err := rl.Acquire("1.2.3.4"); err != nil {
+		t.Fatalf("second acquire: %v", err)
+	}
+	if _, err := rl.Acquire("1.2.3.4"); err == nil {
+		t.Fatal("third concurrent connection from same IP should be rejected")
+	}
+
+	// A different IP is unaffected.
+	if _, err := rl.Acquire("5.6.7.8"); err != nil {
+		t.Fatalf("other IP should be admitted: %v", err)
+	}
+
+	// Releasing one frees a slot.
+	r1()
+	if _, err := rl.Acquire("1.2.3.4"); err != nil {
+		t.Fatalf("acquire after release should succeed: %v", err)
+	}
+}
+
+func TestRateLimiterGlobalCap(t *testing.T) {
+	rl := NewRateLimiter(0, 0, 100, 2 /* maxTotal */)
+	if _, err := rl.Acquire("a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rl.Acquire("b"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rl.Acquire("c"); err == nil {
+		t.Fatal("global cap should reject the third connection regardless of IP")
+	}
+}
+
+func TestRateLimiterRate(t *testing.T) {
+	// 1/min with burst 3, and concurrency uncapped so only the rate bucket
+	// is under test. A very low rate keeps refill negligible during the test.
+	rl := NewRateLimiter(1 /* per min */, 3 /* burst */, 0, 0)
+
+	for i := 0; i < 3; i++ {
+		rel, err := rl.Acquire("9.9.9.9")
+		if err != nil {
+			t.Fatalf("burst acquire %d rejected: %v", i, err)
+		}
+		rel()
+	}
+	if _, err := rl.Acquire("9.9.9.9"); err == nil {
+		t.Fatal("fourth connection should exceed the burst/rate")
+	}
+}
+
+func TestRateLimiterNilAndDisabled(t *testing.T) {
+	var rl *RateLimiter // nil is a valid no-op limiter
+	if rel, err := rl.Acquire("x"); err != nil || rel == nil {
+		t.Fatal("nil limiter should admit everything")
+	}
+
+	// All-zero config disables every check.
+	open := NewRateLimiter(0, 0, 0, 0)
+	for i := 0; i < 50; i++ {
+		if _, err := open.Acquire("y"); err != nil {
+			t.Fatalf("all-zero config should disable limits, got %v", err)
+		}
+	}
+}

--- a/proxy/src/socks.go
+++ b/proxy/src/socks.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -331,65 +332,35 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 	localAddr := target.LocalAddr().(*net.TCPAddr)
 	s.sendReply(SOCKS5_REP_SUCCESS, localAddr.IP, uint16(localAddr.Port))
 
-	// Start proxying data between client and target
+	// Relay data in both directions using a delay line per direction.
+	//
+	// The old relay slept the full one-way latency after EACH 32KB read,
+	// which coupled latency to throughput: a Mars link fell to ~45 bytes/s
+	// and a TLS handshake took over an hour. delayCopy instead shifts every
+	// byte in time by `latency` without blocking subsequent reads, so
+	// throughput is preserved. When one direction finishes it closes its
+	// destination, which unblocks the other direction's read and tears the
+	// tunnel down — the same teardown the original loop used.
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// Client -> Target with celestial body latency
-	go func() {
+	relay := func(dst, src net.Conn, label string) {
 		defer wg.Done()
-		buf := make([]byte, 32*1024)
-		for {
-			n, err := s.conn.Read(buf)
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("Error reading from client: %v", err)
-				}
-				break
-			}
-
-			// Track bandwidth usage
+		// Each direction gets its own context so returning here unblocks
+		// only this direction's internal reader, not the other side.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := delayCopy(ctx, dst, src, latency, func(n int) {
 			s.metrics.TrackBandwidth(bodyName, int64(n))
-
-			// Apply latency for each packet
-			time.Sleep(latency)
-
-			_, err = target.Write(buf[:n])
-			if err != nil {
-				log.Printf("Error writing to target: %v", err)
-				break
-			}
+		})
+		if err != nil && !isNetClosingErr(err) {
+			log.Printf("SOCKS relay %s error: %v", label, err)
 		}
-		target.Close()
-	}()
+		dst.Close() // unblocks the opposite direction's read on this conn
+	}
 
-	// Target -> Client with celestial body latency
-	go func() {
-		defer wg.Done()
-		buf := make([]byte, 32*1024)
-		for {
-			n, err := target.Read(buf)
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("Error reading from target: %v", err)
-				}
-				break
-			}
-
-			// Track bandwidth usage
-			s.metrics.TrackBandwidth(bodyName, int64(n))
-
-			// Apply latency for each packet
-			time.Sleep(latency)
-
-			_, err = s.conn.Write(buf[:n])
-			if err != nil {
-				log.Printf("Error writing to client: %v", err)
-				break
-			}
-		}
-		s.conn.Close()
-	}()
+	go relay(target, s.conn, "client->target")
+	go relay(s.conn, target, "target->client")
 
 	// Wait for both goroutines to complete
 	wg.Wait()

--- a/status/start.sh
+++ b/status/start.sh
@@ -203,6 +203,31 @@ server {
         try_files \$uri \$uri/ /index.html;
     }
 
+    # Live celestial data for the landing page and dashboard. Both fetch
+    # /api/status-data; the proxy container serves it on port 80. Without this
+    # location the request falls through to the SPA and returns index.html
+    # instead of JSON.
+    location = /api/status-data {
+        proxy_pass http://${PROXY_IP}:80/api/status-data;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_cache_bypass \$http_upgrade;
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+
+        # If the proxy is unreachable, serve an empty-but-valid payload so the
+        # page degrades to "no data" rather than a JSON parse error.
+        proxy_intercept_errors on;
+        error_page 500 502 503 504 = @empty_status;
+    }
+
+    location @empty_status {
+        default_type application/json;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        return 200 '{"timestamp":"","objects":{}}';
+    }
+
     # API proxy for metrics - using direct IP address
     location /api/metrics {
         # Handle the request internally and return a simplified default response


### PR DESCRIPTION
Fixes several long-standing issues in the latency proxy, on top of the current `main`.

## Correctness
- **HTTP proxy now works.** The target was passed to `http.NewRequest` with no scheme, and the client timeout `latency * 2 * time.Second` (Duration×Duration) overflowed negative for distant bodies. Now routed through `ValidateDestination` (adds scheme + enforces the allowlist, which the HTTP path previously skipped — it was an open HTTP proxy), timeout derived by addition. Verified live: `example.com` via Moon returns a real page in ~2.5s; non-allowlisted host → 403.
- **`-port` flag honored** (HTTP was hardcoded to `:80`).

## Throughput
- SOCKS relay slept one one-way latency per 32KB chunk (~45 B/s via Mars; TLS handshakes taking hours). Replaced with a delay line (`delay.go`) that shifts bytes in time without throttling. Verified live via Moon: 512KB in 2.4s (was ~40s), 4MB in 11s (was ~5min).

## Abuse controls
- SOCKS and direct HTTP bypass the front-end nginx, so they had no rate limiting. Added a per-IP token bucket + per-IP/global concurrency caps with an idle-bucket janitor (`ratelimit.go`), env-tunable (`MAX_CONNS_PER_IP`, `MAX_CONNS_TOTAL`, `CONN_RATE_PER_MIN`, `CONN_BURST`). Verified live: per-IP cap 2 → two 200s, three 429s.

## Infra
- `status/start.sh` generated nginx now serves `/api/status-data` (the landing page's fetch was falling through to `index.html`).
- nginx subdomain proxy `read/send` timeout 60s → 3600s so bodies past ~30s one-way stop 504'ing.

## Preserved
Keeps the existing ~15-domain destination allowlist and the `<1s` (Earth) proxy rejection — the service stays not-an-open-proxy and Earth stays info-only.

## Tests
Adds tests for the delay line, rate limiter, and HTTP validation. Full deterministic `go test ./...` passes.

**Note:** `TestSocksUDPReliability` / `TestUDPFailureModes` are intermittently flaky under `-race` — confirmed pre-existing (same ~25-50% flake rate on unmodified `main`; this PR doesn't touch the UDP relay).