### PR TITLE
Fix SOCKS CONNECT loopback SSRF and enforce port allowlist

### DIFF
--- a/proxy/src/socks.go
+++ b/proxy/src/socks.go
@@ -224,6 +224,17 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 		return fmt.Errorf("destination not in allowed list: %s", dstAddr)
 	}
 
+	// Enforce the destination port allowlist on the CONNECT/TCP path. This was
+	// previously only checked on the UDP path, so CONNECT could reach any port
+	// (e.g. an allowlisted host on port 22). Skipped in test mode, which dials
+	// echo servers on arbitrary loopback ports.
+	if !isTestMode {
+		if err := s.security.ValidateSocksDestination(dstAddr, dstPort); err != nil {
+			s.sendReply(SOCKS5_REP_CONN_NOT_ALLOWED, net.IPv4zero, 0)
+			return fmt.Errorf("SOCKS destination not allowed: %v", err)
+		}
+	}
+
 	// Extract celestial body and apply latency
 	bodyName, err := s.getCelestialBodyFromConn(s.conn.RemoteAddr())
 	if err != nil {
@@ -718,12 +729,11 @@ func (s *SOCKSHandler) handleUDPRelay(udpConn net.PacketConn, clientTCPAddr net.
 				// Check if the destination host is an IP address
 				isLoopback := false
 				if ip := net.ParseIP(dstHost); ip != nil {
-					// Allow loopback addresses (127.0.0.1, ::1) for testing
-					if ip.IsLoopback() {
-						log.Printf("UDP Relay: Destination %s allowed (loopback)", dstHost)
+					// Loopback is permitted ONLY in test mode; in production
+					// all IP literals are rejected (see isAllowedDestination).
+					if ip.IsLoopback() && isTestMode {
 						isLoopback = true
 					} else {
-						// Reject non-loopback IP addresses
 						log.Printf("UDP Relay: Destination %s is an IP address. Use --socks5-hostname to send domain names to the proxy. Dropping packet.", dstHost)
 						continue
 					}

--- a/proxy/src/socks_helpers.go
+++ b/proxy/src/socks_helpers.go
@@ -92,12 +92,14 @@ func (s *SOCKSHandler) processDomainName(domain string) (string, error) {
 func (s *SOCKSHandler) isAllowedDestination(host string) bool {
 	// Check if this is an IP address
 	if ip := net.ParseIP(host); ip != nil {
-		// Allow loopback addresses (127.0.0.1, ::1) for testing
-		if ip.IsLoopback() {
-			log.Printf("SOCKS destination allowed (loopback): %s", host)
-			return true // Allow loopback immediately for testing
+		// Loopback is permitted ONLY in test mode (the test suite dials
+		// 127.0.0.1 echo servers). In production, allowing loopback would let
+		// an unauthenticated client CONNECT to services on the proxy host,
+		// so all IP literals are rejected — clients must send domain names
+		// (--socks5-hostname) which are then checked against the allowlist.
+		if ip.IsLoopback() && isTestMode {
+			return true
 		}
-		// Reject non-loopback IP addresses
 		log.Printf("SOCKS destination rejected: %s is an IP address. Use --socks5-hostname instead of --socks5 to send domain names to the proxy.", host)
 		return false
 	}

--- a/proxy/src/socks_security_test.go
+++ b/proxy/src/socks_security_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+// TestSOCKSRejectsLoopbackInProduction is the regression test for the SSRF
+// finding: an unauthenticated SOCKS client must not be able to CONNECT to a
+// loopback address in production. Loopback stays allowed only in test mode.
+func TestSOCKSRejectsLoopbackInProduction(t *testing.T) {
+	orig := isTestMode
+	defer func() { isTestMode = orig }()
+
+	h := &SOCKSHandler{security: NewSecurityValidator()}
+
+	isTestMode = false
+	for _, addr := range []string{"127.0.0.1", "::1", "127.0.0.53"} {
+		if h.isAllowedDestination(addr) {
+			t.Errorf("loopback %s must be rejected in production", addr)
+		}
+	}
+	// Non-loopback IP literals are rejected in both modes.
+	if h.isAllowedDestination("169.254.169.254") {
+		t.Error("link-local metadata IP must be rejected")
+	}
+
+	isTestMode = true
+	if !h.isAllowedDestination("127.0.0.1") {
+		t.Error("loopback should be allowed in test mode (tests use echo servers)")
+	}
+}
+
+// TestSOCKSPortAllowlist verifies the port allowlist that the CONNECT path now
+// enforces via ValidateSocksDestination: allowlisted host on a bad port fails.
+func TestSOCKSPortAllowlist(t *testing.T) {
+	s := NewSecurityValidator()
+
+	if err := s.ValidateSocksDestination("github.com", 443); err != nil {
+		t.Errorf("github.com:443 should be allowed: %v", err)
+	}
+	if err := s.ValidateSocksDestination("github.com", 80); err != nil {
+		t.Errorf("github.com:80 should be allowed: %v", err)
+	}
+	// SSH and other non-web ports to an allowlisted host must be rejected —
+	// this is the port-bypass the CONNECT path previously allowed.
+	for _, port := range []uint16{22, 25, 3389, 6379} {
+		if err := s.ValidateSocksDestination("github.com", port); err == nil {
+			t.Errorf("github.com:%d must be rejected (port not allowlisted)", port)
+		}
+	}
+	// Non-allowlisted host rejected regardless of port.
+	if err := s.ValidateSocksDestination("evil.not-listed.example", 443); err == nil {
+		t.Error("non-allowlisted host must be rejected")
+	}
+}


### PR DESCRIPTION
Fixes the security-audit findings on the SOCKS path:

- **Loopback SSRF**: `isAllowedDestination` allowed *any* loopback destination unconditionally (the "for testing" exception was live in production), letting an unauthenticated SOCKS client `CONNECT 127.0.0.1:<port>` and reach services on the proxy host. Now gated behind `isTestMode`; production rejects all IP literals (clients must use `--socks5-hostname`).
- **Port bypass**: `handleConnect` never enforced the port allowlist — `ValidateSocksDestination` was only called on the UDP path — so CONNECT could reach any port on an allowlisted host (e.g. `github.com:22`). Now enforced on the TCP path too.
- The UDP relay shared the same loopback exception; gated identically.

Adds `socks_security_test.go` covering loopback rejection in production mode and the port allowlist. Full suite passes.