### PR TITLE
Document and make the destination allowlist configurable (ALLOWED_HOSTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,38 @@ sudo certbot certonly --standalone -d latency.space -d *.latency.space -d *.*.la
 
 See the [DNS and SSL Configuration Guide](./DNS-AND-SSL-CONFIGURATION.md) for detailed instructions.
 
+### Destination Allowlist
+
+To prevent the service from being used as an open proxy against arbitrary hosts,
+the proxy only relays to an **allowlist** of well-known destination domains (and
+their subdomains), on ports **80, 443, 8080, and 53** only. A request to any
+other host or port is rejected (HTTP `403`; SOCKS5 `connection not allowed`).
+
+The default list covers major search, dev, cloud, reference, social, and media
+sites — Google, Bing, DuckDuckGo, GitHub, Stack Overflow, Microsoft, Apple,
+Cloudflare, Amazon/AWS, Wikipedia, Facebook, YouTube, Reddit, X/Twitter,
+Instagram, LinkedIn, Netflix, BBC, NYTimes, and `example.com`.
+
+**See the live list** any time at:
+
+```bash
+curl http://latency.space/_debug/allowed-hosts
+```
+
+**Adding destinations:**
+
+- **Operators** can extend the list without a code change via the `ALLOWED_HOSTS`
+  environment variable (comma-separated hostnames), merged with the built-in
+  defaults. Set it in `.env`:
+  ```bash
+  ALLOWED_HOSTS=news.ycombinator.com,arstechnica.com
+  ```
+  (Defaults cannot be removed this way, only added. The per-body `socks-*`
+  services enforce the same allowlist; add the variable to their `environment`
+  blocks in `docker-compose.yml` if you need it applied there too.)
+- **Permanent additions** for everyone should be made by editing
+  `allowedHostsList` in `proxy/src/security.go` and opening a pull request.
+
 ### API Endpoint: `/api/status-data`
 
  Provides real-time data for celestial bodies in JSON format, including distance from Earth, calculated one-way light-travel latency, and occlusion status.

--- a/config/example.env
+++ b/config/example.env
@@ -3,3 +3,8 @@ DEPLOY_USER=root
 DISCORD_WEBHOOK=your-discord-webhook
 SSL_EMAIL=your-email@domain.com
 GRAFANA_PASSWORD=your-grafana-password
+
+# Extra destination hosts to allow through the proxy, comma-separated.
+# Merged with the built-in allowlist (see README "Destination Allowlist").
+# Example: ALLOWED_HOSTS=news.ycombinator.com,arstechnica.com
+ALLOWED_HOSTS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
       - proxy_certs:/app/certs
     environment:
       - SOCKS_ENABLED=false # Disable SOCKS5 on main proxy
+      # Extra destination hosts to allow, comma-separated, merged with the
+      # built-in allowlist. Set in .env. The per-body socks-* services below
+      # enforce the same allowlist; add the var to their environment blocks
+      # (or a shared YAML anchor) if you need it there too.
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-}
     cap_add:
       - NET_ADMIN
     restart: unless-stopped

--- a/proxy/src/allowlist_test.go
+++ b/proxy/src/allowlist_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestAllowedHostsEnvMerge verifies ALLOWED_HOSTS extends the default allowlist
+// without removing built-ins.
+func TestAllowedHostsEnvMerge(t *testing.T) {
+	orig, had := os.LookupEnv("ALLOWED_HOSTS")
+	defer func() {
+		if had {
+			os.Setenv("ALLOWED_HOSTS", orig)
+		} else {
+			os.Unsetenv("ALLOWED_HOSTS")
+		}
+	}()
+
+	os.Setenv("ALLOWED_HOSTS", "extra-one.example, Extra-Two.example ,, duplicate.example")
+	s := NewSecurityValidator()
+
+	// New hosts admitted (case-insensitive, trimmed, blanks ignored).
+	for _, h := range []string{"extra-one.example", "extra-two.example", "duplicate.example"} {
+		if !s.IsAllowedHost(h) {
+			t.Errorf("env-added host %q should be allowed", h)
+		}
+	}
+	// Built-in defaults still present.
+	if !s.IsAllowedHost("github.com") {
+		t.Error("built-in allowlist host github.com should remain")
+	}
+	// Unlisted host still rejected.
+	if s.IsAllowedHost("not-added.example") {
+		t.Error("host not in defaults or env must be rejected")
+	}
+}
+
+// TestAllowedHostsAccessorSorted verifies the accessor returns a sorted,
+// non-empty list (used by the /_debug/allowed-hosts endpoint).
+func TestAllowedHostsAccessorSorted(t *testing.T) {
+	os.Unsetenv("ALLOWED_HOSTS")
+	s := NewSecurityValidator()
+	hosts := s.AllowedHosts()
+	if len(hosts) == 0 {
+		t.Fatal("expected a non-empty allowlist")
+	}
+	for i := 1; i < len(hosts); i++ {
+		if hosts[i] < hosts[i-1] {
+			t.Errorf("AllowedHosts not sorted at %d: %q > %q", i, hosts[i-1], hosts[i])
+		}
+	}
+	ports := s.AllowedPorts()
+	if len(ports) == 0 {
+		t.Error("expected non-empty port list")
+	}
+}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -674,11 +674,31 @@ func (s *Server) handleDebugEndpoint(w http.ResponseWriter, r *http.Request) {
 		promhttp.Handler().ServeHTTP(w, r)
 	case "distances":
 		s.printCelestialDistances(w)
+	case "allowed-hosts":
+		s.printAllowedHosts(w)
 	case "help":
 		s.printHelp(w)
 	default:
 		http.Error(w, "Unknown debug command: "+path, http.StatusNotFound)
 	}
+}
+
+// printAllowedHosts lists the destination allowlist (hosts and ports) as JSON.
+// The proxy only relays to these hosts; operators can extend the list via the
+// ALLOWED_HOSTS environment variable.
+func (s *Server) printAllowedHosts(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	payload := map[string]interface{}{
+		"note":  "The proxy only relays to these hosts (and their subdomains) on these ports. Extend via the ALLOWED_HOSTS env var or a PR to security.go.",
+		"hosts": s.security.AllowedHosts(),
+		"ports": s.security.AllowedPorts(),
+	}
+	jsonData, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(jsonData)
 }
 
 // printCelestialDistances shows the current distances of all celestial bodies
@@ -807,6 +827,7 @@ func (s *Server) printHelp(w http.ResponseWriter) {
 	fmt.Fprintln(w, "Debug Endpoints:")
 	fmt.Fprintln(w, "---------------")
 	fmt.Fprintln(w, "/_debug/distances - Current distances and latencies")
+	fmt.Fprintln(w, "/_debug/allowed-hosts - Destination allowlist (hosts and ports)")
 	fmt.Fprintln(w, "/_debug/help - This help information")
 }
 

--- a/proxy/src/security.go
+++ b/proxy/src/security.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
+	"sort"
 	"strconv" // Required for port conversion in ValidateSocksDestination
 	"strings"
 )
@@ -63,6 +65,19 @@ func NewSecurityValidator() *SecurityValidator {
 	allowedHostsMap := make(map[string]bool)
 	for _, host := range allowedHostsList {
 		allowedHostsMap[strings.ToLower(host)] = true // Store lowercase for case-insensitive checks
+	}
+
+	// Operators can extend the allowlist without a code change via the
+	// ALLOWED_HOSTS environment variable (comma-separated hostnames). These
+	// are merged with the built-in defaults; there is no way to remove a
+	// default this way, only add.
+	if extra := os.Getenv("ALLOWED_HOSTS"); extra != "" {
+		for _, host := range strings.Split(extra, ",") {
+			host = strings.TrimSpace(strings.ToLower(host))
+			if host != "" {
+				allowedHostsMap[host] = true
+			}
+		}
 	}
 
 	return &SecurityValidator{
@@ -187,4 +202,27 @@ func (s *SecurityValidator) ValidateSocksDestination(host string, port uint16) e
 func (s *SecurityValidator) IsAllowedIP(ip string) bool {
 	// TODO: Implement rate limiting or IP blocklist checks here if needed.
 	return true
+}
+
+// AllowedHosts returns the sorted list of allowlisted destination hosts.
+// Used to render the live allowlist (e.g. the /_debug/allowed-hosts endpoint).
+func (s *SecurityValidator) AllowedHosts() []string {
+	hosts := make([]string, 0, len(s.allowedHosts))
+	for h := range s.allowedHosts {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+// AllowedPorts returns the sorted list of allowlisted destination ports.
+func (s *SecurityValidator) AllowedPorts() []string {
+	ports := make([]string, 0, len(s.allowedPorts))
+	for p := range s.allowedPorts {
+		if p != "" {
+			ports = append(ports, p)
+		}
+	}
+	sort.Strings(ports)
+	return ports
 }


### PR DESCRIPTION
Addresses the two allowlist follow-ups.

**Docs (1):** README now has a *Destination Allowlist* section — the rationale (anti-open-proxy), the covered domains, ports (80/443/8080/53), how to view the live list (`/_debug/allowed-hosts`), and how to add destinations.

**Config (2):** `ALLOWED_HOSTS` env var (comma-separated) merges with the built-in defaults, so operators can add destinations without a code change. New `/_debug/allowed-hosts` JSON endpoint exposes the live list; plumbed through `docker-compose.yml` and `config/example.env`.

Tested: env merge, accessors, and the endpoint verified live locally (an `ALLOWED_HOSTS`-added host shows up in the endpoint output). Full suite passes.