### PR TITLE
Rolling deploys: stop nuking the whole stack every time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     environment: production
-    concurrency: production
+    # Queue deploys instead of cancelling a running one mid-flight (a cancelled
+    # deploy could leave the stack half-rolled). Rolling up -d makes each deploy
+    # idempotent, so serial execution is safe.
+    concurrency:
+      group: production
+      cancel-in-progress: false
     # Removed continue-on-error to ensure workflow fails if deployment fails
     # This ensures deployment issues are properly reported
     steps:
@@ -245,13 +250,10 @@ jobs:
               fi
             fi
             
-            # Stopping containers safely
-            echo "Stopping all containers..."
-            docker ps -q | xargs -r docker stop || true
-            
-            # Attempt to manually remove stopped containers if needed
-            docker ps -aq | xargs -r docker rm -f || true
-            
+            # NB: no blanket stop/rm of containers here. update.sh does a rolling
+            # `docker compose up -d --build` that recreates only changed services,
+            # so the stack stays up during the deploy.
+
             # Run the update script without special snap Docker handling
             echo "Running update script..."
             if ! sudo -E ./deploy/update.sh; then
@@ -270,20 +272,14 @@ jobs:
                 fi
               done
 
-              # Attempt to directly start containers with security options disabled
+              # Last-resort recovery if the rolling update failed: recreate the
+              # stack. NB: NO `docker volume prune` here — with containers down it
+              # would delete the named data volumes (grafana/prometheus/certs).
               cd /opt/latency-space
               docker compose down || true
-              
-              # Try to remove any Docker containers and volumes that might be causing issues
-              echo "Attempting to clean up Docker resources..."
               docker container prune -f || true
-              docker volume prune -f || true
-              
-              # Build and start without AppArmor configuration
               echo "Building fresh images..."
-              docker compose build --no-cache
-              
-              # Start services normally without additional options
+              docker compose build
               echo "Starting services..."
               docker compose up -d
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -66,10 +66,9 @@ blue "📥 Pulling latest code from GitHub..."
 git fetch origin
 git reset --hard origin/main
 
-# Clean up any stuck containers with very forceful approach
-blue "🧹 Cleaning up any problematic containers..."
-# Stop all containers 
-docker ps -aq | xargs -r docker stop || true
+# NB: deliberately NOT stopping all containers here. A rolling `docker compose
+# up -d --build` later recreates only the services that actually changed, so the
+# stack stays up during deploys instead of a full stop/start window.
 
 # Fix Docker bridge network conflicts
 blue "🌉 Checking for Docker bridge network conflicts..."
@@ -258,17 +257,15 @@ fi
 
 green "✅ No external port conflicts detected"
 
-# Restart the containers
-blue "🔄 Restarting all containers..."
+# Roll out changed containers only — near-zero downtime.
+blue "🔄 Building (with layer cache) and rolling out changed containers..."
 cd /opt/latency-space
-docker compose down
-blue "🏗️ Building all proxy images..."
-docker compose build --no-cache
-
-echo ""
-blue "🚀 Starting containers..."
-# Allow docker compose up to fail without exiting script (for diagnostics)
-docker compose up -d || true
+# `docker compose up -d --build` recreates only services whose image or config
+# changed, one at a time; unchanged containers keep running. We deliberately do
+# NOT `docker compose down` or build `--no-cache`: those tore the whole stack
+# down on every deploy (≈1 min outage) and the cache-less builds filled the disk
+# (the root cause of the 2026 outage).
+docker compose up -d --build --remove-orphans || true
 
 # Give containers a moment to start
 sleep 3


### PR DESCRIPTION
**Root cause of the deploy downtime / 'site broke':** every deploy ran `docker stop`+`docker rm -f` on **all** containers, then `docker compose down` + `build --no-cache` + `up -d` — a full ~1-minute outage on every deploy, compounded when multiple deploys collide.

**Fix:**
- `update.sh`: rolling `docker compose up -d --build --remove-orphans` (recreates only changed services, layer cache) instead of down + no-cache rebuild; removed the pre-emptive stop-all.
- `main.yml`: dropped the blanket `docker stop`/`rm -f` before the deploy; made `concurrency` explicit (`cancel-in-progress: false` so deploys queue instead of cancelling mid-roll); and removed `docker volume prune -f` from the fallback (data-loss risk — it would delete grafana/prometheus/cert volumes when containers are down).

Shell + YAML validated. This makes deploys effectively downtime-free and immune to the multi-merge collision.