### PR TITLE
Fix data races on test-mode and celestial-object globals

### DIFF
--- a/proxy/src/auth_latency_test.go
+++ b/proxy/src/auth_latency_test.go
@@ -246,11 +246,11 @@ func TestSOCKSLatencyValues(t *testing.T) {
 	defer cleanup()
 
 	// Need control over test mode latency values
-	originalTestMode := isTestMode
-	defer func() { isTestMode = originalTestMode }()
+	originalTestMode := isTestMode.Load()
+	defer func() { isTestMode.Store(originalTestMode) }()
 
 	// We'll override the test mode latency for this test
-	isTestMode = true
+	isTestMode.Store(true)
 
 	// Setup security and metrics
 	security := NewSecurityValidator()
@@ -626,8 +626,8 @@ func TestSOCKSOcclusion(t *testing.T) {
 	// This test will simulate occlusion scenarios for SOCKS proxy
 
 	// Create a custom celestial objects setup for occlusion testing
-	originalCelestialObjects := celestialObjects
-	defer func() { celestialObjects = originalCelestialObjects }()
+	originalCelestialObjects := getCelestialObjects()
+	defer func() { setCelestialObjects(originalCelestialObjects) }()
 
 	// Create mock objects
 	mockSun := CelestialObject{
@@ -655,7 +655,7 @@ func TestSOCKSOcclusion(t *testing.T) {
 	}
 
 	// Set up our test celestial objects
-	celestialObjects = testBodies
+	setCelestialObjects(testBodies)
 
 	// Setup security and metrics
 	security := NewSecurityValidator()

--- a/proxy/src/calculations.go
+++ b/proxy/src/calculations.go
@@ -8,21 +8,39 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/latency-space/shared/celestial"
 )
 
-var celestialObjects []celestial.CelestialObject
+// celestialObjectsPtr holds the solar-system snapshot. Atomic because tests swap
+// it while SOCKS UDP relay goroutines may still be reading it (a data race under
+// -race); production sets it once in init() and never mutates it afterwards.
+// Always access via getCelestialObjects/setCelestialObjects, never the pointer.
+var celestialObjectsPtr atomic.Pointer[[]celestial.CelestialObject]
 var DistanceCacheMutex sync.RWMutex // Exported mutex for cache access
 
+// getCelestialObjects returns the current solar-system snapshot (nil if unset).
+func getCelestialObjects() []celestial.CelestialObject {
+	if p := celestialObjectsPtr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// setCelestialObjects atomically replaces the solar-system snapshot.
+func setCelestialObjects(objs []celestial.CelestialObject) {
+	celestialObjectsPtr.Store(&objs)
+}
+
 func init() {
-	celestialObjects = celestial.InitSolarSystemObjects()
-	log.Printf("Celestial objects initialized. Count: %d", len(celestialObjects))
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+	log.Printf("Celestial objects initialized. Count: %d", len(getCelestialObjects()))
 
 	// Debug: Verify Sun is in the list
 	sunFound := false
-	for _, obj := range celestialObjects {
+	for _, obj := range getCelestialObjects() {
 		if obj.Name == "Sun" {
 			sunFound = true
 			break
@@ -35,7 +53,7 @@ func init() {
 
 func CalculateLatency(distanceKm float64) time.Duration {
 	// Use test mode with fixed low latency if enabled
-	if isTestMode {
+	if isTestMode.Load() {
 		return testModeCalculateLatency(distanceKm)
 	}
 
@@ -546,7 +564,7 @@ func getCurrentDistance(bodyName string) float64 {
 	}
 
 	//log.Printf("Size of celestialObjects: %d", len(celestialObjects))
-	calculateDistancesFromEarth(celestialObjects, time.Now()) // Ensure cache is potentially updated (handles its own locking)
+	calculateDistancesFromEarth(getCelestialObjects(), time.Now()) // Ensure cache is potentially updated (handles its own locking)
 
 	DistanceCacheMutex.RLock()         // Acquire read lock to access the cache
 	defer DistanceCacheMutex.RUnlock() // Ensure lock is released
@@ -564,7 +582,7 @@ func getCurrentDistance(bodyName string) float64 {
 
 // Display objects of a specific type
 func printObjectsByType(w io.Writer, objectType string) {
-	calculateDistancesFromEarth(celestialObjects, time.Now()) // Ensure cache is potentially updated
+	calculateDistancesFromEarth(getCelestialObjects(), time.Now()) // Ensure cache is potentially updated
 
 	DistanceCacheMutex.RLock()         // Acquire read lock
 	defer DistanceCacheMutex.RUnlock() // Ensure lock is released

--- a/proxy/src/calculations_test.go
+++ b/proxy/src/calculations_test.go
@@ -59,9 +59,9 @@ func TestDistinctSpacecraftDistances(t *testing.T) {
 	// Set the global celestialObjects for the test context IF NEEDED by dependencies
 	// Since calculateDistancesFromEarth takes objects as arg, we don't strictly need this
 	// But GetObjectPosition relies on the global slice if ParentName lookups occur
-	originalCelestialObjects := celestialObjects                   // backup
-	celestialObjects = testObjects                                 // set global for GetObjectPosition
-	defer func() { celestialObjects = originalCelestialObjects }() // restore
+	originalCelestialObjects := getCelestialObjects()                // backup
+	setCelestialObjects(testObjects)                                 // set global for GetObjectPosition
+	defer func() { setCelestialObjects(originalCelestialObjects) }() // restore
 
 	calculateDistancesFromEarth(testObjects, testTime)
 

--- a/proxy/src/extended_socks_test.go
+++ b/proxy/src/extended_socks_test.go
@@ -18,7 +18,7 @@ import (
 // with multiple celestial bodies at different distances
 func setupExtendedTestEnv() (func(), map[string]CelestialObject) {
 	// Save original objects
-	originalCelestialObjects := celestialObjects
+	originalCelestialObjects := getCelestialObjects()
 
 	// Create multiple test celestial objects with varying distances/latencies
 	testBodies := []CelestialObject{
@@ -95,7 +95,7 @@ func setupExtendedTestEnv() (func(), map[string]CelestialObject) {
 	}
 
 	// Override global celestial objects
-	celestialObjects = testBodies
+	setCelestialObjects(testBodies)
 
 	// Create a map for easy lookup in tests
 	bodyMap := make(map[string]CelestialObject)
@@ -105,7 +105,7 @@ func setupExtendedTestEnv() (func(), map[string]CelestialObject) {
 
 	// Return cleanup function and the body map
 	return func() {
-		celestialObjects = originalCelestialObjects
+		setCelestialObjects(originalCelestialObjects)
 	}, bodyMap
 }
 

--- a/proxy/src/http_proxy_test.go
+++ b/proxy/src/http_proxy_test.go
@@ -46,12 +46,12 @@ func TestValidateDestinationSchemeAndAllowlist(t *testing.T) {
 // allowlist on the HTTP proxy path (previously it had no check at all, so any
 // host embedded in the subdomain was proxied — an open HTTP proxy).
 func TestHTTPProxyRejectsNonAllowlistedHost(t *testing.T) {
-	orig := celestialObjects
-	celestialObjects = []CelestialObject{
+	orig := getCelestialObjects()
+	setCelestialObjects([]CelestialObject{
 		{Name: "Earth", Type: "planet"},
 		{Name: "Mars", Type: "planet"},
-	}
-	defer func() { celestialObjects = orig }()
+	})
+	defer func() { setCelestialObjects(orig) }()
 
 	s := newTestServer()
 
@@ -72,12 +72,12 @@ func TestHTTPProxyRejectsNonAllowlistedHost(t *testing.T) {
 // network fetch — which is exactly the point where we can confirm validation
 // (scheme prepend + allowlist) succeeded without making a real request.
 func TestHTTPProxyAllowlistedHostPassesValidation(t *testing.T) {
-	orig := celestialObjects
-	celestialObjects = []CelestialObject{
+	orig := getCelestialObjects()
+	setCelestialObjects([]CelestialObject{
 		{Name: "Earth", Type: "planet"},
 		{Name: "Mars", Type: "planet"},
-	}
-	defer func() { celestialObjects = orig }()
+	})
+	defer func() { setCelestialObjects(orig) }()
 
 	cleanup := setupTestModeWithLatency(3 * time.Millisecond)
 	defer cleanup()

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -235,9 +235,9 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Accessing for |%s|, via body |%s|", targetURL, bodyName)
 
-	if celestialObjects == nil {
+	if getCelestialObjects() == nil {
 		log.Printf("Init celestial objects")
-		celestialObjects = celestial.InitSolarSystemObjects()
+		setCelestialObjects(celestial.InitSolarSystemObjects())
 	}
 
 	// If there's no target URL, just display info about this celestial body
@@ -261,13 +261,13 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	targetURL = validatedURL
 
 	// Find the target and Earth objects
-	targetObject, targetFound := findObjectByName(celestialObjects, bodyName)
+	targetObject, targetFound := findObjectByName(getCelestialObjects(), bodyName)
 	if !targetFound {
 		log.Printf("Error: Target celestial body '%s' not found after host parsing.", bodyName)
 		http.Error(w, "Internal server error: Target body not found", http.StatusInternalServerError)
 		return
 	}
-	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
+	earthObject, earthFound := findObjectByName(getCelestialObjects(), "Earth")
 	if !earthFound {
 		log.Printf("Error: Earth celestial object not found.")
 		http.Error(w, "Internal server error: Earth object configuration missing", http.StatusInternalServerError)
@@ -275,7 +275,7 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check for occlusion
-	occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+	occluded, occluder := IsOccluded(earthObject, targetObject, getCelestialObjects(), time.Now())
 	if occluded {
 		// If occluded is true, occluder is guaranteed to be non-nil by IsOccluded
 		log.Printf("HTTP connection to %s rejected: occluded by %s", bodyName, occluder.Name)
@@ -391,11 +391,11 @@ func (s *Server) displayCelestialInfo(w http.ResponseWriter, name string) {
 	var occluded bool
 	var occluderName string
 	var occluder CelestialObject // Use struct type to match IsOccluded return type
-	targetObject, targetFound := findObjectByName(celestialObjects, name)
-	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
+	targetObject, targetFound := findObjectByName(getCelestialObjects(), name)
+	earthObject, earthFound := findObjectByName(getCelestialObjects(), "Earth")
 
 	if targetFound && earthFound {
-		occluded, occluder = IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+		occluded, occluder = IsOccluded(earthObject, targetObject, getCelestialObjects(), time.Now())
 		// Check if an actual occluding object was returned (Name will be non-empty)
 		if occluded && occluder.Name != "" {
 			occluderName = occluder.Name
@@ -467,8 +467,8 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 	}
 
 	// Ensure celestial objects are initialized
-	if celestialObjects == nil {
-		celestialObjects = celestial.InitSolarSystemObjects()
+	if getCelestialObjects() == nil {
+		setCelestialObjects(celestial.InitSolarSystemObjects())
 	}
 
 	// Check if it's a latency.space domain (case-insensitive manual check)
@@ -493,8 +493,8 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 		potentialMoonName := parts[numParts-4]
 		potentialPlanetName := parts[numParts-3]
 
-		moon, moonFound := findObjectByName(celestialObjects, potentialMoonName)
-		planet, planetFound := findObjectByName(celestialObjects, potentialPlanetName)
+		moon, moonFound := findObjectByName(getCelestialObjects(), potentialMoonName)
+		planet, planetFound := findObjectByName(getCelestialObjects(), potentialPlanetName)
 
 		// If both potential moon and planet are found, perform strict validation
 		if moonFound && planetFound {
@@ -528,7 +528,7 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 	// Case 4: [planet].latency.space (3 parts, target is empty)
 	if numParts >= 3 {
 		potentialBodyName := parts[numParts-3]
-		body, bodyFound := findObjectByName(celestialObjects, potentialBodyName)
+		body, bodyFound := findObjectByName(getCelestialObjects(), potentialBodyName)
 
 		// Check if body is found and is not a moon (case-insensitive check to avoid conflict with moon.planet format)
 		if bodyFound && !strings.EqualFold(body.Type, "moon") {
@@ -545,7 +545,7 @@ func (s *Server) parseHostForCelestialBody(host string, reqURL *url.URL) (string
 	// This handles the case where someone just goes to mars.latency.space
 	if numParts == 3 {
 		potentialBodyName := parts[0]
-		body, bodyFound := findObjectByName(celestialObjects, potentialBodyName)
+		body, bodyFound := findObjectByName(getCelestialObjects(), potentialBodyName)
 		if bodyFound {
 			return "", body, body.Name
 		}
@@ -726,7 +726,7 @@ func (s *Server) handleStatusData(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure distance data is up-to-date
 	now := time.Now()
-	calculateDistancesFromEarth(celestialObjects, now) // Refresh cache
+	calculateDistancesFromEarth(getCelestialObjects(), now) // Refresh cache
 	log.Printf("DEBUG: distanceEntries after calculation: %+v\n", distanceEntries)
 
 	// Prepare the response structure
@@ -740,7 +740,7 @@ func (s *Server) handleStatusData(w http.ResponseWriter, r *http.Request) {
 	defer DistanceCacheMutex.RUnlock() // Ensure lock is released
 
 	// Populate the response data
-	for _, obj := range celestialObjects {
+	for _, obj := range getCelestialObjects() {
 		if obj.Type == "star" { // Skip the Sun for this endpoint
 			continue
 		}
@@ -885,11 +885,11 @@ func main() {
 	}
 
 	// Initialize celestial objects for calculation
-	celestialObjects = celestial.InitSolarSystemObjects()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
 
 	// Validate fixed celestial body if set
 	if fixedCelestialBody != "" {
-		_, found := findObjectByName(celestialObjects, fixedCelestialBody)
+		_, found := findObjectByName(getCelestialObjects(), fixedCelestialBody)
 		if !found {
 			log.Fatalf("Invalid CELESTIAL_BODY: '%s' not found in solar system objects", fixedCelestialBody)
 		}

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -26,9 +26,9 @@ var testCelestialObjects = []CelestialObject{
 
 func TestParseHostForCelestialBody(t *testing.T) {
 	// Override global celestialObjects with test data for this specific test.
-	originalCelestialObjects := celestialObjects
-	celestialObjects = testCelestialObjects
-	defer func() { celestialObjects = originalCelestialObjects }() // Restore original celestialObjects data after the test completes.
+	originalCelestialObjects := getCelestialObjects()
+	setCelestialObjects(testCelestialObjects)
+	defer func() { setCelestialObjects(originalCelestialObjects) }() // Restore original celestialObjects data after the test completes.
 
 	// dummyURL is used as a placeholder for the URL argument, as it's not used by the function.
 	dummyURL, _ := url.Parse("http://example.com")
@@ -173,9 +173,9 @@ func TestParseHostForCelestialBody(t *testing.T) {
 // TestFindObjectByName tests the helper function directly.
 func TestFindObjectByName(t *testing.T) {
 	// Use the same test object data.
-	originalCelestialObjects := celestialObjects
-	celestialObjects = testCelestialObjects
-	defer func() { celestialObjects = originalCelestialObjects }()
+	originalCelestialObjects := getCelestialObjects()
+	setCelestialObjects(testCelestialObjects)
+	defer func() { setCelestialObjects(originalCelestialObjects) }()
 
 	testCases := []struct {
 		name          string
@@ -198,7 +198,7 @@ func TestFindObjectByName(t *testing.T) {
 			if tc.name == "Find planet in nil slice" {
 				objectsToSearch = nil
 			} else {
-				objectsToSearch = celestialObjects
+				objectsToSearch = getCelestialObjects()
 			}
 
 			foundBody, found := findObjectByName(objectsToSearch, tc.searchName)
@@ -221,14 +221,14 @@ func TestFindObjectByName(t *testing.T) {
 // TestDisplayCelestialInfoTemplate tests the rendering of the info page HTML template.
 func TestDisplayCelestialInfoTemplate(t *testing.T) {
 	// Initialize real celestial objects data.
-	celestialObjects = celestial.InitSolarSystemObjects()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
 	// Ensure celestialObjects were loaded.
-	if len(celestialObjects) == 0 {
+	if len(getCelestialObjects()) == 0 {
 		t.Fatal("Failed to initialize celestialObjects (slice is nil or empty)")
 	}
 
 	// Populate the distance cache.
-	calculateDistancesFromEarth(celestialObjects, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	calculateDistancesFromEarth(getCelestialObjects(), time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	// Parse the HTML template.
 	var err error

--- a/proxy/src/socks.go
+++ b/proxy/src/socks.go
@@ -228,7 +228,7 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 	// previously only checked on the UDP path, so CONNECT could reach any port
 	// (e.g. an allowlisted host on port 22). Skipped in test mode, which dials
 	// echo servers on arbitrary loopback ports.
-	if !isTestMode {
+	if !isTestMode.Load() {
 		if err := s.security.ValidateSocksDestination(dstAddr, dstPort); err != nil {
 			s.sendReply(SOCKS5_REP_CONN_NOT_ALLOWED, net.IPv4zero, 0)
 			return fmt.Errorf("SOCKS destination not allowed: %v", err)
@@ -243,26 +243,26 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 	}
 
 	// --- Occlusion Check ---
-	if celestialObjects == nil {
+	if getCelestialObjects() == nil {
 		log.Printf("Error: celestialObjects not initialized during SOCKS request.")
 		s.sendReply(SOCKS5_REP_GENERAL_FAILURE, net.IPv4zero, 0)
 		return fmt.Errorf("internal server error: celestial objects not initialized")
 	}
 
-	targetObject, targetFound := findObjectByName(celestialObjects, bodyName)
+	targetObject, targetFound := findObjectByName(getCelestialObjects(), bodyName)
 	if !targetFound {
 		log.Printf("Error: SOCKS: Target celestial body '%s' not found.", bodyName)
 		s.sendReply(SOCKS5_REP_GENERAL_FAILURE, net.IPv4zero, 0)
 		return fmt.Errorf("internal server error: target body '%s' not found", bodyName)
 	}
-	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
+	earthObject, earthFound := findObjectByName(getCelestialObjects(), "Earth")
 	if !earthFound {
 		log.Printf("Error: SOCKS: Earth celestial object not found.")
 		s.sendReply(SOCKS5_REP_GENERAL_FAILURE, net.IPv4zero, 0)
 		return fmt.Errorf("internal server error: earth object configuration missing")
 	}
 
-	occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+	occluded, occluder := IsOccluded(earthObject, targetObject, getCelestialObjects(), time.Now())
 	if occluded {
 		// If occluded is true, occluder is guaranteed to be non-nil by IsOccluded
 		log.Printf("SOCKS connection to %s rejected: occluded by %s", bodyName, occluder.Name)
@@ -276,7 +276,7 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 	distance := getCurrentDistance(bodyName) // Get distance for latency calc
 	var latency time.Duration
 	// Use test latency in test mode
-	if isTestMode {
+	if isTestMode.Load() {
 		latency = testModeCalculateLatency(distance)
 	} else {
 		latency = CalculateLatency(distance)
@@ -285,7 +285,7 @@ func (s *SOCKSHandler) handleConnect(addrType byte) error {
 	// Anti-DDoS: Only allow bodies with significant latency (>1s)
 	// This prevents the proxy from being used for DDoS attacks
 	// Skip this check in test mode
-	if !isTestMode && latency < 1*time.Second {
+	if !isTestMode.Load() && latency < 1*time.Second {
 		log.Printf("Rejecting connection with insufficient latency: %s (%.2f ms)",
 			bodyName, latency.Seconds()*1000)
 		s.sendReply(SOCKS5_REP_GENERAL_FAILURE, net.IPv4zero, 0)
@@ -513,7 +513,7 @@ func (s *SOCKSHandler) handleUDPRelay(udpConn net.PacketConn, clientTCPAddr net.
 	distance := getCurrentDistance(bodyName)
 	var latency time.Duration
 	// Use test latency in test mode
-	if isTestMode {
+	if isTestMode.Load() {
 		latency = testModeCalculateLatency(distance)
 	} else {
 		latency = CalculateLatency(distance)
@@ -521,12 +521,12 @@ func (s *SOCKSHandler) handleUDPRelay(udpConn net.PacketConn, clientTCPAddr net.
 	log.Printf("UDP Relay for %s: Using body '%s', latency %v", clientTCPAddr, bodyName, latency)
 
 	// Get Earth object for occlusion check (assuming Earth is the proxy location)
-	earthObject, earthFound := findObjectByName(celestialObjects, "Earth")
+	earthObject, earthFound := findObjectByName(getCelestialObjects(), "Earth")
 	if !earthFound {
 		log.Printf("Error: UDP Relay: Earth celestial object not found. Occlusion checks disabled.")
 		// Proceed without occlusion checks if Earth object is missing
 	}
-	targetObject, targetFound := findObjectByName(celestialObjects, bodyName)
+	targetObject, targetFound := findObjectByName(getCelestialObjects(), bodyName)
 	if !targetFound {
 		log.Printf("Error: UDP Relay: Target celestial body '%s' not found. Occlusion checks disabled.", bodyName)
 		// Proceed without occlusion checks if target object is missing
@@ -731,7 +731,7 @@ func (s *SOCKSHandler) handleUDPRelay(udpConn net.PacketConn, clientTCPAddr net.
 				if ip := net.ParseIP(dstHost); ip != nil {
 					// Loopback is permitted ONLY in test mode; in production
 					// all IP literals are rejected (see isAllowedDestination).
-					if ip.IsLoopback() && isTestMode {
+					if ip.IsLoopback() && isTestMode.Load() {
 						isLoopback = true
 					} else {
 						log.Printf("UDP Relay: Destination %s is an IP address. Use --socks5-hostname to send domain names to the proxy. Dropping packet.", dstHost)
@@ -751,7 +751,7 @@ func (s *SOCKSHandler) handleUDPRelay(udpConn net.PacketConn, clientTCPAddr net.
 
 				// --- Occlusion Check ---
 				if earthFound && targetFound { // Only check if we found both Earth and the target body
-					occluded, occluder := IsOccluded(earthObject, targetObject, celestialObjects, time.Now())
+					occluded, occluder := IsOccluded(earthObject, targetObject, getCelestialObjects(), time.Now())
 					if occluded {
 						log.Printf("UDP Relay: Path to %s occluded by %s, dropping packet.", bodyName, occluder.Name)
 						continue

--- a/proxy/src/socks_helpers.go
+++ b/proxy/src/socks_helpers.go
@@ -75,7 +75,7 @@ func (s *SOCKSHandler) processDomainName(domain string) (string, error) {
 
 		// Get the celestial body name for logging
 		bodyName := parts[bodyIndex]
-		_, found := findObjectByName(celestialObjects, bodyName)
+		_, found := findObjectByName(getCelestialObjects(), bodyName)
 
 		if !found {
 			return "", fmt.Errorf("unknown celestial body: %s", bodyName)
@@ -97,7 +97,7 @@ func (s *SOCKSHandler) isAllowedDestination(host string) bool {
 		// an unauthenticated client CONNECT to services on the proxy host,
 		// so all IP literals are rejected — clients must send domain names
 		// (--socks5-hostname) which are then checked against the allowlist.
-		if ip.IsLoopback() && isTestMode {
+		if ip.IsLoopback() && isTestMode.Load() {
 			return true
 		}
 		log.Printf("SOCKS destination rejected: %s is an IP address. Use --socks5-hostname instead of --socks5 to send domain names to the proxy.", host)
@@ -169,7 +169,7 @@ func (s *SOCKSHandler) getCelestialBodyFromConn(addr net.Addr) (string, error) {
 			// The celestial body is the second-to-last part before "latency.space"
 			bodyIndex := len(parts) - 3
 			bodyName := parts[bodyIndex]
-			celestialBody, found := findObjectByName(celestialObjects, bodyName)
+			celestialBody, found := findObjectByName(getCelestialObjects(), bodyName)
 			if found {
 				log.Printf("Using celestial body from domain: %s", celestialBody.Name)
 				return celestialBody.Name, nil
@@ -180,7 +180,7 @@ func (s *SOCKSHandler) getCelestialBodyFromConn(addr net.Addr) (string, error) {
 	// Check if the first part of the hostname is a celestial body
 	hostParts := strings.Split(host, ".")
 	if len(hostParts) > 0 {
-		body, found := findObjectByName(celestialObjects, hostParts[0])
+		body, found := findObjectByName(getCelestialObjects(), hostParts[0])
 		if found {
 			log.Printf("Using celestial body from hostname: %s", body.Name)
 			return body.Name, nil
@@ -189,6 +189,6 @@ func (s *SOCKSHandler) getCelestialBodyFromConn(addr net.Addr) (string, error) {
 
 	// For clients connecting directly via IP, use Mars with minimal latency for testing
 	log.Printf("No celestial body detected in hostname, using Mars for connection from |%s|", host)
-	body, _ := findObjectByName(celestialObjects, "Mars")
+	body, _ := findObjectByName(getCelestialObjects(), "Mars")
 	return body.Name, nil
 }

--- a/proxy/src/socks_security_test.go
+++ b/proxy/src/socks_security_test.go
@@ -6,12 +6,12 @@ import "testing"
 // finding: an unauthenticated SOCKS client must not be able to CONNECT to a
 // loopback address in production. Loopback stays allowed only in test mode.
 func TestSOCKSRejectsLoopbackInProduction(t *testing.T) {
-	orig := isTestMode
-	defer func() { isTestMode = orig }()
+	orig := isTestMode.Load()
+	defer func() { isTestMode.Store(orig) }()
 
 	h := &SOCKSHandler{security: NewSecurityValidator()}
 
-	isTestMode = false
+	isTestMode.Store(false)
 	for _, addr := range []string{"127.0.0.1", "::1", "127.0.0.53"} {
 		if h.isAllowedDestination(addr) {
 			t.Errorf("loopback %s must be rejected in production", addr)
@@ -22,7 +22,7 @@ func TestSOCKSRejectsLoopbackInProduction(t *testing.T) {
 		t.Error("link-local metadata IP must be rejected")
 	}
 
-	isTestMode = true
+	isTestMode.Store(true)
 	if !h.isAllowedDestination("127.0.0.1") {
 		t.Error("loopback should be allowed in test mode (tests use echo servers)")
 	}

--- a/proxy/src/socks_test.go
+++ b/proxy/src/socks_test.go
@@ -17,10 +17,10 @@ func setupTestEnvironment() func() {
 	// Need Earth for occlusion checks and a target body (e.g., Mars) for latency simulation context
 	// Assign the test objects to the global variable used by the main code
 	// Save the original celestial objects to restore them later
-	originalCelestialObjects := celestialObjects
+	originalCelestialObjects := getCelestialObjects()
 
 	// Override global celestial objects with test-specific ones with low latency
-	celestialObjects = []CelestialObject{
+	setCelestialObjects([]CelestialObject{
 		{
 			Name:   "Sun",
 			Type:   "star",
@@ -67,13 +67,13 @@ func setupTestEnvironment() func() {
 			Mass:   6.4171e23, // kg
 		},
 		// Add other bodies if needed for specific tests
-	}
+	})
 	// Suppress log output during tests unless debugging
 	// log.SetOutput(io.Discard) // Keep log suppression commented out for now
 
 	// Return a cleanup function to restore the original celestial objects
 	return func() {
-		celestialObjects = originalCelestialObjects
+		setCelestialObjects(originalCelestialObjects)
 	}
 }
 

--- a/proxy/src/test_helpers.go
+++ b/proxy/src/test_helpers.go
@@ -2,13 +2,19 @@
 
 package main
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
-// Variable to enable test mode - shared between test files
-var isTestMode = false
+// Test-mode flags. Atomic because test goroutines (e.g. the SOCKS UDP relay)
+// can still be running and reading these when a test's cleanup resets them —
+// plain reads/writes there are a data race under -race. In production these
+// are set once at startup and never mutated.
+var isTestMode atomic.Bool
 
-// Variables to override test behavior for specific tests
-var testModeLatencyOverride time.Duration
+// testModeLatencyOverride holds a fixed latency (nanoseconds) for tests; 0 = unset.
+var testModeLatencyOverride atomic.Int64
 
 // UDP relay close delay for testing connection termination
 // nolint:unused
@@ -16,39 +22,29 @@ var testModeUDPRelayCloseDelay time.Duration = 500 * time.Millisecond
 
 // setupTestMode enables test mode for latency calculations and returns a cleanup function
 func setupTestMode() func() {
-	// Set test mode
-	isTestMode = true
-
-	// Reset latency override
-	testModeLatencyOverride = 0
-
-	// Return a function to reset it
+	isTestMode.Store(true)
+	testModeLatencyOverride.Store(0)
 	return func() {
-		isTestMode = false
-		testModeLatencyOverride = 0
+		isTestMode.Store(false)
+		testModeLatencyOverride.Store(0)
 	}
 }
 
 // setupTestModeWithLatency enables test mode with a specific latency and returns a cleanup function
 func setupTestModeWithLatency(latency time.Duration) func() {
-	// Set test mode
-	isTestMode = true
-
-	// Set latency override
-	testModeLatencyOverride = latency
-
-	// Return a function to reset it
+	isTestMode.Store(true)
+	testModeLatencyOverride.Store(int64(latency))
 	return func() {
-		isTestMode = false
-		testModeLatencyOverride = 0
+		isTestMode.Store(false)
+		testModeLatencyOverride.Store(0)
 	}
 }
 
 // testModeCalculateLatency returns configurable latency for testing
 func testModeCalculateLatency(distance float64) time.Duration {
 	// If we have an override set, use that
-	if testModeLatencyOverride > 0 {
-		return testModeLatencyOverride
+	if v := testModeLatencyOverride.Load(); v > 0 {
+		return time.Duration(v)
 	}
 
 	// Default test latency

--- a/proxy/src/tls.go
+++ b/proxy/src/tls.go
@@ -35,7 +35,7 @@ func isValidSubdomain(host string) bool {
 	// Requires exactly 3 parts: body.latency.space
 	if numParts == 3 {
 		bodyName := parts[0]
-		_, found := findObjectByName(celestialObjects, bodyName)
+		_, found := findObjectByName(getCelestialObjects(), bodyName)
 		return found // Valid if the body name exists
 	}
 
@@ -44,7 +44,7 @@ func isValidSubdomain(host string) bool {
 	if numParts == 4 {
 		moonName := parts[0]
 		planetName := parts[1]
-		moon, moonFound := findObjectByName(celestialObjects, moonName)
+		moon, moonFound := findObjectByName(getCelestialObjects(), moonName)
 		// Check if moon exists, is a moon, and its parent matches the planet part
 		return moonFound && moon.Type == "moon" && strings.EqualFold(moon.ParentName, planetName)
 	}
@@ -54,7 +54,7 @@ func isValidSubdomain(host string) bool {
 	if numParts >= 4 {
 		bodyName := parts[numParts-3]
 		// Check if it's a valid celestial body (non-moon)
-		body, found := findObjectByName(celestialObjects, bodyName)
+		body, found := findObjectByName(getCelestialObjects(), bodyName)
 		if found && body.Type != "moon" {
 			return true
 		}
@@ -64,8 +64,8 @@ func isValidSubdomain(host string) bool {
 		if numParts >= 5 {
 			moonName := parts[numParts-4]
 			planetName := parts[numParts-3]
-			moon, moonFound := findObjectByName(celestialObjects, moonName)
-			_, planetFound := findObjectByName(celestialObjects, planetName)
+			moon, moonFound := findObjectByName(getCelestialObjects(), moonName)
+			_, planetFound := findObjectByName(getCelestialObjects(), planetName)
 			// Check if moon and planet exist, moon type is correct, and parent matches
 			if moonFound && planetFound && moon.Type == "moon" && strings.EqualFold(moon.ParentName, planetName) {
 				return true


### PR DESCRIPTION
## What

Eliminates the `go test -race` failures in the SOCKS UDP relay path. A still-running relay goroutine could read package globals while a test's deferred cleanup restored them — a genuine data race, not flaky timing.

## Changes

- **`isTestMode` / `testModeLatencyOverride`** → `sync/atomic` (`atomic.Bool`, `atomic.Int64`); all reads use `.Load()`, all writes `.Store()`.
- **`celestialObjects`** → `atomic.Pointer[[]CelestialObject]` behind `getCelestialObjects()` / `setCelestialObjects()` accessors. This also removes the latent race on `main.go`'s lazy `if celestialObjects == nil { ... }` init checks.

## Semantics

Production behaviour is unchanged: both globals are set once at startup (package `init` / `main`) and never mutated afterwards. The atomic pointer stores an immutable slice snapshot, so readers always see a consistent value.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- Full test suite passes under `-race` across repeated runs (UDP subset 10/10, full suite 4/4) — previously ~30-50% of runs reported `DATA RACE`.