### PR TITLE
Fix deploy build + multi-word body subdomain resolution

### DIFF
--- a/proxy/src/calculations.go
+++ b/proxy/src/calculations.go
@@ -469,7 +469,14 @@ func IsOccluded(observer, target celestial.CelestialObject, objects []celestial.
 // Helper function to find an object by name
 func findObjectByName(objects []celestial.CelestialObject, name string) (celestial.CelestialObject, bool) {
 	for _, obj := range objects {
-		if obj.Name == name || strings.EqualFold(obj.Name, name) {
+		// Match the raw name (case-insensitively) and also the subdomain slug
+		// form, where spaces become hyphens (e.g. "Voyager 1" -> "voyager-1").
+		// Without the slug match, multi-word bodies are unreachable via their
+		// advertised subdomain. Done inline (not via FormatDomainName) so this
+		// file stays self-contained for the DNS tool's symlinked build.
+		if obj.Name == name ||
+			strings.EqualFold(obj.Name, name) ||
+			strings.EqualFold(strings.ReplaceAll(obj.Name, " ", "-"), name) {
 			return obj, true
 		}
 	}

--- a/proxy/src/main_test.go
+++ b/proxy/src/main_test.go
@@ -22,6 +22,8 @@ var testCelestialObjects = []CelestialObject{
 	{Name: "Phobos", Type: "moon", ParentName: "Mars"},
 	{Name: "Deimos", Type: "moon", ParentName: "Mars"},
 	{Name: "Europa", Type: "moon", ParentName: "Jupiter"},
+	// Multi-word name: advertised subdomain is the hyphenated slug "voyager-1".
+	{Name: "Voyager 1", Type: "spacecraft"},
 }
 
 func TestParseHostForCelestialBody(t *testing.T) {
@@ -53,6 +55,20 @@ func TestParseHostForCelestialBody(t *testing.T) {
 			expectedURL:      "",
 			expectedBody:     testCelestialObjects[4], // Phobos
 			expectedBodyName: "Phobos",
+		},
+		{
+			name:             "Multi-word body via hyphenated slug",
+			host:             "voyager-1.latency.space",
+			expectedURL:      "",
+			expectedBody:     testCelestialObjects[7], // Voyager 1
+			expectedBodyName: "Voyager 1",
+		},
+		{
+			name:             "Multi-word body slug with target",
+			host:             "www.example.com.voyager-1.latency.space",
+			expectedURL:      "www.example.com",
+			expectedBody:     testCelestialObjects[7], // Voyager 1
+			expectedBodyName: "Voyager 1",
 		},
 		{
 			name:             "Planet format with target",

--- a/tools/test_helpers.go
+++ b/tools/test_helpers.go
@@ -2,20 +2,22 @@
 
 package main
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
-// Variable to enable test mode - shared between test files
-var isTestMode = false
+// Variable to enable test mode - shared between test files.
+// atomic.Bool to match the proxy build, whose calculations.go (symlinked into
+// this tool) reads it via isTestMode.Load().
+var isTestMode atomic.Bool
 
 // setupTestMode enables test mode for latency calculations and returns a cleanup function
 // nolint:unused
 func setupTestMode() func() {
-	// Set test mode
-	isTestMode = true
-	
-	// Return a function to reset it
+	isTestMode.Store(true)
 	return func() {
-		isTestMode = false
+		isTestMode.Store(false)
 	}
 }
 


### PR DESCRIPTION
Two fixes needed for the site to work end to end. Found while testing the live deployment.

## 1. DNS tool build (deploy blocker)

PR #80 made `proxy/src/calculations.go` read `isTestMode` via `.Load()` (atomic). The deploy job's **Update DNS Configuration** step symlinks `calculations.go` into `tools/` and compiles it, but `tools/test_helpers.go` still declared `isTestMode` as a plain `bool`:

```
./calculations.go:56:16: isTestMode.Load undefined (type bool has no field or method Load)
```

That failed the deploy job and the container-deploy steps were **skipped** (production stayed on the previous image — no outage, but #80 never went live). Fixed by mirroring the `atomic.Bool` declaration in `tools/test_helpers.go`.

## 2. Multi-word body subdomains returned 400 (functional bug)

`findObjectByName` compared the incoming subdomain label only against the raw object `Name`. Bodies whose names contain spaces — **Voyager 1, Voyager 2, New Horizons, Parker Solar Probe** — advertise a hyphenated slug subdomain (`voyager-1.latency.space`) but the lookup never reversed the slug, so every one returned `Unknown celestial body` (HTTP 400). Single-token bodies (mars, jupiter, eris, jwst) were unaffected.

Fixed by also matching the hyphen-for-space slug form, inline so `calculations.go` stays self-contained for the symlinked DNS-tool build. Regression cases added to `TestParseHostForCelestialBody`.

## Verification

- Full proxy suite passes; `TestParseHostForCelestialBody` covers the new slug cases.
- Reproduced the CI symlink build locally (`ln -fs ../proxy/src/calculations.go .` + `go build .`) — compiles.