### PR TITLE
Multi-wildcard cert tooling for 2-level body subdomains

### DIFF
--- a/.github/workflows/wildcard-certs.yml
+++ b/.github/workflows/wildcard-certs.yml
@@ -1,0 +1,42 @@
+name: Wildcard Certs
+
+# Reissue the latency.space certificate with per-parent-body wildcard SANs so
+# second-level body pages (moon.planet.latency.space) validate over HTTPS.
+# Manual only - certificate issuance is rate-limited and outward-facing, so it
+# is never run automatically. Leave dry_run=true first to validate the DNS-01
+# flow against Let's Encrypt staging without issuing a real certificate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (validate DNS-01 against staging, issue nothing)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: wildcard-certs
+  cancel-in-progress: false
+
+jobs:
+  reissue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reissue certificate on the host
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: 22
+          envs: CLOUDFLARE_API_TOKEN,SSL_EMAIL,DRY_RUN
+          script: |
+            set -e
+            cd /opt/latency-space
+            git pull --ff-only || git pull
+            chmod +x deploy/setup-wildcard-certs.sh
+            deploy/setup-wildcard-certs.sh
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          SSL_EMAIL: ${{ secrets.SSL_EMAIL }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ port). The per-body subdomains serve information pages only.
 
 **Note on SSL certificates:**
 - First-level subdomains (`mars.latency.space`) are covered by the `*.latency.space` wildcard.
-- Second-level subdomains (e.g., `phobos.mars.latency.space`) need per-parent wildcard SANs (`*.mars.latency.space`, …), issued via DNS-01.
+- Second-level subdomains (e.g., `phobos.mars.latency.space`) need per-parent wildcard SANs (`*.mars.latency.space`, …), issued via DNS-01. Run `deploy/setup-wildcard-certs.sh` on the host (or trigger the **Wildcard Certs** GitHub Action, which defaults to a safe dry run) to reissue the certificate with those SANs.
 
 For proper SSL certificate configuration covering all domain levels:
 ```bash

--- a/deploy/setup-wildcard-certs.sh
+++ b/deploy/setup-wildcard-certs.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# setup-wildcard-certs.sh
+#
+# Reissue the latency.space Let's Encrypt certificate so it also covers the
+# second-level body subdomains (moon.planet.latency.space). Those hosts are
+# routed by nginx and served by the proxy, but the current certificate is a
+# single-level "*.latency.space" wildcard, which by definition does NOT match a
+# two-label name like phobos.mars.latency.space - so HTTPS fails there.
+#
+# The fix is one certificate with per-parent-body wildcard SANs. A wildcard SAN
+# can only be issued via the DNS-01 challenge, done here through Cloudflare.
+#
+# The certificate keeps --cert-name "latency.space", so it lands at the same
+# path nginx already references (/etc/letsencrypt/live/latency.space/), and the
+# renewal deploy-hook installed by vps-maintenance-setup.sh reloads nginx on
+# every future renewal. No nginx change is required.
+#
+# Prerequisites on the host:
+#   - certbot with the dns-cloudflare plugin (this script installs it if missing)
+#   - a Cloudflare API token with Zone:DNS:Edit on the latency.space zone,
+#     provided via the CLOUDFLARE_API_TOKEN environment variable
+#
+# Usage:
+#   CLOUDFLARE_API_TOKEN=xxxx SSL_EMAIL=you@example.com ./deploy/setup-wildcard-certs.sh
+#
+#   DRY_RUN=1 CLOUDFLARE_API_TOKEN=xxxx ./deploy/setup-wildcard-certs.sh
+#     Validate the whole DNS-01 flow against the Let's Encrypt staging endpoint
+#     WITHOUT issuing a real certificate or touching production. Run this first.
+#
+set -euo pipefail
+
+CERT_NAME="latency.space"
+SSL_EMAIL="${SSL_EMAIL:-bruce@fitzsimons.org}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# Parent bodies that currently have moons. Each needs a wildcard SAN so its
+# moons validate at moon.<parent>.latency.space. Regenerate with:
+#   curl -s https://latency.space/api/status-data \
+#     | python3 -c 'import sys,json;o=[x for v in json.load(sys.stdin)["objects"].values() for x in v];print(*sorted({m["parentName"].lower().replace(" ","-") for m in o if m.get("type")=="moon" and m.get("parentName")}))'
+PARENTS=(earth jupiter mars neptune pluto saturn uranus)
+
+if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  echo "ERROR: CLOUDFLARE_API_TOKEN is not set (needs Zone:DNS:Edit on latency.space)." >&2
+  exit 1
+fi
+
+# Build the domain argument list: apex + single-level wildcard + one wildcard
+# per parent body.
+DOMAIN_ARGS=(-d "latency.space" -d "*.latency.space")
+for p in "${PARENTS[@]}"; do
+  DOMAIN_ARGS+=(-d "*.${p}.latency.space")
+done
+
+echo "Certificate '${CERT_NAME}' will cover:"
+printf '  %s\n' "latency.space" "*.latency.space"
+for p in "${PARENTS[@]}"; do printf '  %s\n' "*.${p}.latency.space"; done
+
+# Ensure certbot + the Cloudflare DNS plugin are present.
+if ! command -v certbot >/dev/null 2>&1 || ! certbot plugins 2>/dev/null | grep -q dns-cloudflare; then
+  echo "Installing certbot + python3-certbot-dns-cloudflare..."
+  if command -v apt-get >/dev/null 2>&1; then
+    apt-get update -qq
+    apt-get install -y certbot python3-certbot-dns-cloudflare
+  elif command -v dnf >/dev/null 2>&1; then
+    dnf install -y certbot python3-certbot-dns-cloudflare
+  else
+    echo "ERROR: no supported package manager found; install certbot + dns-cloudflare manually." >&2
+    exit 1
+  fi
+fi
+
+# Write the Cloudflare credentials to a locked-down temp file and remove it on exit.
+CF_CREDS="$(mktemp)"
+chmod 600 "$CF_CREDS"
+trap 'rm -f "$CF_CREDS"' EXIT
+printf 'dns_cloudflare_api_token = %s\n' "$CLOUDFLARE_API_TOKEN" > "$CF_CREDS"
+
+CERTBOT_ARGS=(
+  certonly
+  --dns-cloudflare
+  --dns-cloudflare-credentials "$CF_CREDS"
+  --dns-cloudflare-propagation-seconds 30
+  --cert-name "$CERT_NAME"
+  --non-interactive
+  --agree-tos
+  --email "$SSL_EMAIL"
+  --expand
+  --keep-until-expiring
+  "${DOMAIN_ARGS[@]}"
+)
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo ">>> DRY RUN: validating DNS-01 against staging, no certificate issued."
+  certbot "${CERTBOT_ARGS[@]}" --dry-run
+  echo "Dry run succeeded. Re-run without DRY_RUN=1 to issue the real certificate."
+  exit 0
+fi
+
+certbot "${CERTBOT_ARGS[@]}"
+
+echo "Reloading nginx to serve the new certificate..."
+if nginx -t; then
+  systemctl reload nginx
+  echo "Done. nginx is now serving the multi-wildcard certificate."
+else
+  echo "ERROR: nginx config test failed; NOT reloading. Investigate before proceeding." >&2
+  exit 1
+fi


### PR DESCRIPTION
Implements issue #1 from the end-to-end review: make `moon.planet.latency.space` pages work over HTTPS. (Reopens #83, which auto-closed when its stacked base branch merged; now rebased onto main.)

## Problem

nginx already routes 2-level names to the proxy and the proxy serves them, but the live certificate is a single-level `*.latency.space` wildcard. A TLS wildcard matches exactly one label, so `phobos.mars.latency.space` fails with a cert-name mismatch. Verified live.

## Fix

One certificate with per-parent-body wildcard SANs. Wildcards require DNS-01, done via Cloudflare.

- **`deploy/setup-wildcard-certs.sh`** — reissues the cert with `latency.space`, `*.latency.space`, and `*.<parent>.latency.space` for the 7 parents that currently have moons (earth, jupiter, mars, neptune, pluto, saturn, uranus). Uses `--cert-name latency.space` so it lands at the path nginx already references (no nginx change); tests config and reloads nginx after. `DRY_RUN=1` validates the full DNS-01 flow against Let's Encrypt **staging** without issuing.
- **`.github/workflows/wildcard-certs.yml`** — manual `workflow_dispatch` to run it on the host over SSH using existing secrets. Defaults to `dry_run=true`. Never runs automatically (issuance is rate-limited and outward-facing).
- **README** — points at the script/workflow from the SSL note.

## How to run

1. Trigger **Wildcard Certs** with `dry_run` checked → confirms Cloudflare DNS-01 end to end.
2. Re-trigger with `dry_run` unchecked → issues the real cert and reloads nginx.

## Not runnable in CI

Actual issuance happens on the host against Let's Encrypt with the production Cloudflare token; can't be exercised in PR CI. `bash -n` clean; workflow YAML validated.