### PR TITLE
Scope Wildcard Certs workflow to production environment

### DIFF
--- a/.github/workflows/wildcard-certs.yml
+++ b/.github/workflows/wildcard-certs.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   reissue:
     runs-on: ubuntu-latest
+    # DEPLOY_HOST/USER, SSH_PRIVATE_KEY, CLOUDFLARE_API_TOKEN and SSL_EMAIL are
+    # scoped to the production environment (same as the main deploy job).
+    environment: production
     steps:
       - name: Reissue certificate on the host
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
One-line fix: the cert workflow's SSH/Cloudflare secrets are scoped to the `production` GitHub Environment (same as the main deploy job), so the job needs `environment: production` to read them. Without it the dry run failed with `missing server host`.