### PR TITLE
DTN store-and-forward delivery for distant bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,29 @@ echo "dns-query-data" | nc -u -X 5 -x latency.space:1080 1.1.1.1 53
 echo "dns-query-data" | nc -u -X 5 -x latency.space:1081 1.1.1.1 53
 ```
 
+### Store-and-Forward (DTN) for distant bodies
+
+A transparent proxy can't serve a body that is hours or days away — the client
+socket times out long before the simulated delay elapses. For those bodies,
+requests are delivered asynchronously, the way real deep-space networks move
+data: you submit a request, get a job id immediately, and poll for the response.
+The server models both light-travel legs (out and back).
+
+```bash
+# Submit a request "to" a destination via Voyager 1 (~24h one way)
+curl -X POST https://voyager-1.latency.space/dtn/send \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com/","method":"GET"}'
+# -> { "id":"...", "state":"in_transit", "estimatedDeliveryAt":"...", "statusUrl":"/dtn/status/..." }
+
+# Poll until state is "delivered" (or "failed")
+curl https://voyager-1.latency.space/dtn/status/<id>
+```
+
+- The body is taken from the host subdomain, or from a `"via":"Voyager 1"` field when posting to the apex.
+- States: `in_transit` (outbound) → `arriving` → `returning` → `delivered` / `failed`. The response is withheld until it has finished travelling back.
+- Destinations are restricted to the same allowlist as the proxy. Jobs persist across restarts and are retained for 7 days after delivery.
+
 ### A note on domain-embedding URLs
 
 An older URL form embedded the target in the hostname

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - proxy_config:/etc/space-proxy
       - proxy_ssl:/etc/letsencrypt
       - proxy_certs:/app/certs
+      - proxy_data:/data # DTN store-and-forward jobs (persist across restarts)
     environment:
       - SOCKS_ENABLED=false # Disable SOCKS5 on main proxy
       # Extra destination hosts to allow, comma-separated, merged with the
@@ -319,3 +320,4 @@ volumes:
   proxy_config:
   proxy_ssl:
   proxy_certs:
+  proxy_data:

--- a/proxy/src/dtn.go
+++ b/proxy/src/dtn.go
@@ -1,0 +1,313 @@
+// dtn.go - Delay/Disruption-Tolerant Networking: store-and-forward delivery for
+// bodies whose light-travel latency far exceeds any client's timeout.
+//
+// A transparent proxy cannot serve a body that is hours or days away: the client
+// socket times out long before the simulated delay elapses. Instead, a caller
+// POSTs a request to /dtn/send, gets a job id back immediately, and polls
+// /dtn/status/{id}. The server models both legs of the light-travel delay: the
+// request "arrives" at the destination at submit + one-way, is fetched then, and
+// the response is "delivered" one-way later. This mirrors how deep-space networks
+// actually move data.
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	dtnMaxBodyBytes = 1 << 20            // cap stored request/response bodies at 1 MiB
+	dtnRetention    = 7 * 24 * time.Hour // keep delivered jobs this long after delivery
+	dtnFetchTimeout = 60 * time.Second   // real network timeout for the actual fetch
+)
+
+// DTNJob is a single store-and-forward request and its (eventual) response.
+type DTNJob struct {
+	ID          string            `json:"id"`
+	Body        string            `json:"body"` // celestial body name
+	OneWay      time.Duration     `json:"oneWayNs"`
+	SubmittedAt time.Time         `json:"submittedAt"`
+	Method      string            `json:"method"`
+	URL         string            `json:"url"`
+	ReqHeaders  map[string]string `json:"reqHeaders,omitempty"`
+	ReqBody     string            `json:"reqBody,omitempty"`
+
+	// Filled in once the outbound request "arrives" and the fetch runs.
+	Fetched     bool              `json:"fetched"`
+	FetchedAt   time.Time         `json:"fetchedAt,omitempty"`
+	RespStatus  int               `json:"respStatus,omitempty"`
+	RespHeaders map[string]string `json:"respHeaders,omitempty"`
+	RespBody    string            `json:"respBody,omitempty"`
+	FetchErr    string            `json:"fetchErr,omitempty"`
+}
+
+func (j *DTNJob) arrivalAt() time.Time  { return j.SubmittedAt.Add(j.OneWay) }
+func (j *DTNJob) deliveryAt() time.Time { return j.arrivalAt().Add(j.OneWay) }
+
+// state returns the human-facing lifecycle stage at time now.
+func (j *DTNJob) state(now time.Time) string {
+	if !j.Fetched {
+		if now.Before(j.arrivalAt()) {
+			return "in_transit" // request still travelling outbound
+		}
+		return "arriving" // request has reached the destination; fetch pending
+	}
+	if now.Before(j.FetchedAt.Add(j.OneWay)) {
+		return "returning" // response travelling back to Earth
+	}
+	if j.FetchErr != "" {
+		return "failed"
+	}
+	return "delivered"
+}
+
+// DTNStore holds jobs, persists them to disk, and schedules the fetch leg.
+type DTNStore struct {
+	path     string
+	security *SecurityValidator
+	metrics  *MetricsCollector
+
+	mu     sync.Mutex
+	jobs   map[string]*DTNJob
+	timers map[string]*time.Timer
+}
+
+// NewDTNStore builds a store backed by the given file and loads any saved jobs.
+func NewDTNStore(path string, security *SecurityValidator, metrics *MetricsCollector) *DTNStore {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		_ = os.MkdirAll(dir, 0o700) // best effort; save() logs if writes still fail
+	}
+	s := &DTNStore{
+		path:     path,
+		security: security,
+		metrics:  metrics,
+		jobs:     make(map[string]*DTNJob),
+		timers:   make(map[string]*time.Timer),
+	}
+	s.load()
+	return s
+}
+
+// load reads persisted jobs (best effort - a missing or corrupt file is ignored).
+func (s *DTNStore) load() {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return
+	}
+	var jobs []*DTNJob
+	if err := json.Unmarshal(data, &jobs); err != nil {
+		log.Printf("DTN: ignoring unreadable store %s: %v", s.path, err)
+		return
+	}
+	for _, j := range jobs {
+		s.jobs[j.ID] = j
+	}
+	log.Printf("DTN: loaded %d job(s) from %s", len(jobs), s.path)
+}
+
+// save writes all jobs atomically. Caller must hold s.mu.
+func (s *DTNStore) save() {
+	if s.path == "" {
+		return
+	}
+	jobs := make([]*DTNJob, 0, len(s.jobs))
+	for _, j := range s.jobs {
+		jobs = append(jobs, j)
+	}
+	data, err := json.MarshalIndent(jobs, "", "  ")
+	if err != nil {
+		log.Printf("DTN: marshal failed: %v", err)
+		return
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		log.Printf("DTN: write failed: %v", err)
+		return
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		log.Printf("DTN: rename failed: %v", err)
+	}
+}
+
+// Start reschedules the fetch leg for any pending jobs (surviving a restart) and
+// launches the retention janitor. stop closes to shut the janitor down.
+func (s *DTNStore) Start(stop <-chan struct{}) {
+	s.mu.Lock()
+	for _, j := range s.jobs {
+		if !j.Fetched {
+			s.scheduleFetchLocked(j)
+		}
+	}
+	s.mu.Unlock()
+
+	go func() {
+		t := time.NewTicker(time.Hour)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				s.sweep()
+			}
+		}
+	}()
+}
+
+// scheduleFetchLocked arms a timer to fetch the destination when the outbound
+// request "arrives". If arrival is already in the past (e.g. after a restart),
+// the fetch runs immediately. Caller must hold s.mu.
+func (s *DTNStore) scheduleFetchLocked(j *DTNJob) {
+	delay := time.Until(j.arrivalAt())
+	if delay < 0 {
+		delay = 0
+	}
+	id := j.ID
+	s.timers[id] = time.AfterFunc(delay, func() { s.runFetch(id) })
+}
+
+// runFetch performs the real HTTP request for a job and records the result.
+func (s *DTNStore) runFetch(id string) {
+	s.mu.Lock()
+	j, ok := s.jobs[id]
+	delete(s.timers, id)
+	if !ok || j.Fetched {
+		s.mu.Unlock()
+		return
+	}
+	// Snapshot the immutable request fields; release the lock during network I/O.
+	method, rawURL, reqHeaders, reqBody := j.Method, j.URL, j.ReqHeaders, j.ReqBody
+	s.mu.Unlock()
+
+	status, respHeaders, respBody, fetchErr := s.fetch(method, rawURL, reqHeaders, reqBody)
+
+	s.mu.Lock()
+	j, ok = s.jobs[id]
+	var bodyName string
+	if ok {
+		j.Fetched = true
+		j.FetchedAt = time.Now()
+		j.RespStatus = status
+		j.RespHeaders = respHeaders
+		j.RespBody = respBody
+		j.FetchErr = fetchErr
+		bodyName = j.Body
+		s.save()
+	}
+	s.mu.Unlock()
+
+	if s.metrics != nil && ok {
+		s.metrics.RecordRequest(bodyName, "dtn", 0)
+	}
+}
+
+// fetch does the actual outbound request. Returns status, headers, body, error.
+func (s *DTNStore) fetch(method, rawURL string, headers map[string]string, body string) (int, map[string]string, string, string) {
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, rawURL, reqBody)
+	if err != nil {
+		return 0, nil, "", fmt.Sprintf("build request: %v", err)
+	}
+	for k, v := range headers {
+		if !strings.EqualFold(k, "host") {
+			req.Header.Set(k, v)
+		}
+	}
+	client := &http.Client{Timeout: dtnFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, "", fmt.Sprintf("fetch: %v", err)
+	}
+	defer resp.Body.Close()
+
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, dtnMaxBodyBytes))
+	rh := make(map[string]string, len(resp.Header))
+	for k := range resp.Header {
+		rh[k] = resp.Header.Get(k)
+	}
+	return resp.StatusCode, rh, string(rb), ""
+}
+
+// sweep drops jobs whose retention window has passed.
+func (s *DTNStore) sweep() {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	changed := false
+	for id, j := range s.jobs {
+		if j.Fetched && now.After(j.FetchedAt.Add(j.OneWay).Add(dtnRetention)) {
+			delete(s.jobs, id)
+			changed = true
+		}
+	}
+	if changed {
+		s.save()
+	}
+}
+
+// Add validates and stores a new job, then schedules its fetch.
+func (s *DTNStore) Add(bodyName, method, rawURL string, headers map[string]string, body string, oneWay time.Duration) (*DTNJob, error) {
+	validatedURL, err := s.security.ValidateHTTPTarget(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if method == "" {
+		method = http.MethodGet
+	}
+	if len(body) > dtnMaxBodyBytes {
+		return nil, fmt.Errorf("request body exceeds %d bytes", dtnMaxBodyBytes)
+	}
+
+	j := &DTNJob{
+		ID:          newDTNID(),
+		Body:        bodyName,
+		OneWay:      oneWay,
+		SubmittedAt: time.Now(),
+		Method:      strings.ToUpper(method),
+		URL:         validatedURL,
+		ReqHeaders:  headers,
+		ReqBody:     body,
+	}
+
+	s.mu.Lock()
+	s.jobs[j.ID] = j
+	s.scheduleFetchLocked(j)
+	s.save()
+	snap := *j
+	s.mu.Unlock()
+	return &snap, nil
+}
+
+// Get returns a snapshot of a job by id, copied under the lock so callers can
+// read it without racing the fetch goroutine that mutates the stored job.
+// Response header/body maps are assigned once (never mutated after) so sharing
+// them in the copy is safe.
+func (s *DTNStore) Get(id string) (*DTNJob, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return nil, false
+	}
+	snap := *j
+	return &snap, true
+}
+
+func newDTNID() string {
+	var b [12]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}

--- a/proxy/src/dtn_http.go
+++ b/proxy/src/dtn_http.go
@@ -1,0 +1,136 @@
+// dtn_http.go - HTTP surface for the DTN store-and-forward API.
+//
+//	POST /dtn/send          submit a request; returns a job id
+//	GET  /dtn/status/{id}   poll a job; returns the response once "delivered"
+//
+// The celestial body is taken from the request host (e.g. voyager-1.latency.space)
+// or from the "via" field in the JSON body.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// dtnSendRequest is the JSON accepted by POST /dtn/send.
+type dtnSendRequest struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Payload string            `json:"payload,omitempty"` // request body
+	Via     string            `json:"via,omitempty"`     // celestial body, if host is the apex
+}
+
+func (s *Server) handleDTN(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/dtn/send":
+		s.handleDTNSend(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/dtn/status/"):
+		s.handleDTNStatus(w, r)
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error": "unknown DTN endpoint; use POST /dtn/send or GET /dtn/status/{id}",
+		})
+	}
+}
+
+func (s *Server) handleDTNSend(w http.ResponseWriter, r *http.Request) {
+	// Abuse control, same as the other proxy paths.
+	release, err := s.limiter.Acquire(clientIP(r.RemoteAddr))
+	if err != nil {
+		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
+		return
+	}
+	defer release()
+
+	var req dtnSendRequest
+	dec := json.NewDecoder(io.LimitReader(r.Body, dtnMaxBodyBytes))
+	if err := dec.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body: " + err.Error()})
+		return
+	}
+
+	// Resolve the celestial body: prefer the host subdomain, fall back to "via".
+	bodyName := s.resolveCelestialHost(r.Host)
+	if bodyName == "" && req.Via != "" {
+		if obj, ok := findObjectByName(getCelestialObjects(), req.Via); ok {
+			bodyName = obj.Name
+		}
+	}
+	if bodyName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "no celestial body: POST to a body host (e.g. voyager-1.latency.space) or set \"via\"",
+		})
+		return
+	}
+
+	oneWay := CalculateLatency(getCurrentDistance(bodyName))
+	job, err := s.dtn.Add(bodyName, req.Method, req.URL, req.Headers, req.Payload, oneWay)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, map[string]interface{}{
+		"id":                   job.ID,
+		"body":                 job.Body,
+		"state":                job.state(time.Now()),
+		"oneWayLatencySeconds": job.OneWay.Seconds(),
+		"submittedAt":          job.SubmittedAt,
+		"arrivesAt":            job.arrivalAt(),
+		"estimatedDeliveryAt":  job.deliveryAt(),
+		"statusUrl":            "/dtn/status/" + job.ID,
+	})
+}
+
+func (s *Server) handleDTNStatus(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/dtn/status/")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing job id"})
+		return
+	}
+	job, ok := s.dtn.Get(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no such job (it may have expired)"})
+		return
+	}
+
+	now := time.Now()
+	state := job.state(now)
+	out := map[string]interface{}{
+		"id":                   job.ID,
+		"body":                 job.Body,
+		"state":                state,
+		"oneWayLatencySeconds": job.OneWay.Seconds(),
+		"submittedAt":          job.SubmittedAt,
+		"arrivesAt":            job.arrivalAt(),
+		"estimatedDeliveryAt":  job.deliveryAt(),
+	}
+
+	// The response is only revealed once it has finished travelling back to Earth.
+	switch state {
+	case "delivered":
+		out["response"] = map[string]interface{}{
+			"status":  job.RespStatus,
+			"headers": job.RespHeaders,
+			"body":    job.RespBody,
+		}
+	case "failed":
+		out["error"] = job.FetchErr
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// writeJSON writes v as an indented JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}

--- a/proxy/src/dtn_test.go
+++ b/proxy/src/dtn_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/latency-space/shared/celestial"
+)
+
+// newDTNTestServer builds a Server wired with a DTN store at a temp path, without
+// NewServer (which registers global Prometheus metrics). A nil limiter is a
+// no-op, which is what we want here.
+func newDTNTestServer(t *testing.T) *Server {
+	t.Helper()
+	sec := NewSecurityValidator()
+	s := &Server{security: sec, metrics: NewTestMetricsCollector(), httpEnabled: true}
+	s.dtn = NewDTNStore(t.TempDir()+"/dtn.json", sec, s.metrics)
+	return s
+}
+
+func dtnSend(t *testing.T, s *Server, host, jsonBody string) (int, map[string]interface{}) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "http://x/dtn/send", strings.NewReader(jsonBody))
+	req.Host = host
+	rec := httptest.NewRecorder()
+	s.handleDTN(rec, req)
+	var out map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	return rec.Code, out
+}
+
+func dtnStatus(t *testing.T, s *Server, id string) (int, map[string]interface{}) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "http://x/dtn/status/"+id, nil)
+	rec := httptest.NewRecorder()
+	s.handleDTN(rec, req)
+	var out map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	return rec.Code, out
+}
+
+// TestDTNLifecycle drives a job from submission through delivery, checking that
+// the response is withheld until both light-travel legs have "elapsed".
+func TestDTNLifecycle(t *testing.T) {
+	// One-way latency of 40ms keeps the test fast but leaves a window where the
+	// job is observably in transit before it is delivered (~80ms round trip).
+	defer setupTestModeWithLatency(40 * time.Millisecond)()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+
+	// Destination echo server.
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "hello from space")
+	}))
+	defer dest.Close()
+
+	s := newDTNTestServer(t)
+
+	code, out := dtnSend(t, s, "mars.latency.space",
+		fmt.Sprintf(`{"url":%q,"method":"GET"}`, dest.URL))
+	if code != http.StatusAccepted {
+		t.Fatalf("send: expected 202, got %d (%v)", code, out)
+	}
+	id, _ := out["id"].(string)
+	if id == "" {
+		t.Fatalf("send: no job id in %v", out)
+	}
+	if out["body"] != "Mars" {
+		t.Errorf("send: expected body Mars, got %v", out["body"])
+	}
+
+	// Immediately after submission the request is still travelling outbound.
+	_, st := dtnStatus(t, s, id)
+	if state := st["state"]; state != "in_transit" && state != "arriving" {
+		t.Errorf("early state: expected in_transit/arriving, got %v", state)
+	}
+	if _, leaked := st["response"]; leaked {
+		t.Error("response must not be revealed before delivery")
+	}
+
+	// Poll until delivered (bounded).
+	var final map[string]interface{}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_, final = dtnStatus(t, s, id)
+		if final["state"] == "delivered" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if final["state"] != "delivered" {
+		t.Fatalf("job never delivered; last state %v", final["state"])
+	}
+	resp, ok := final["response"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("delivered job missing response: %v", final)
+	}
+	if resp["status"].(float64) != http.StatusOK {
+		t.Errorf("expected status 200, got %v", resp["status"])
+	}
+	if body, _ := resp["body"].(string); body != "hello from space" {
+		t.Errorf("expected echoed body, got %q", body)
+	}
+}
+
+// TestDTNRejectsNonAllowlistedHost verifies the allowlist is enforced on submit.
+func TestDTNRejectsNonAllowlistedHost(t *testing.T) {
+	defer setupTestMode()()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+	s := newDTNTestServer(t)
+
+	code, out := dtnSend(t, s, "mars.latency.space",
+		`{"url":"https://evil.not-listed-anywhere.example/"}`)
+	if code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-allowlisted host, got %d (%v)", code, out)
+	}
+}
+
+// TestDTNRequiresBody verifies a body must be identified (host or "via").
+func TestDTNRequiresBody(t *testing.T) {
+	defer setupTestMode()()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+	s := newDTNTestServer(t)
+
+	// Apex host, no "via".
+	code, _ := dtnSend(t, s, "latency.space", `{"url":"https://example.com/"}`)
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when no body is identified, got %d", code)
+	}
+
+	// "via" fills it in.
+	code, out := dtnSend(t, s, "latency.space", `{"url":"https://example.com/","via":"Jupiter"}`)
+	if code != http.StatusAccepted {
+		t.Fatalf("expected 202 with via=Jupiter, got %d (%v)", code, out)
+	}
+	if out["body"] != "Jupiter" {
+		t.Errorf("expected body Jupiter, got %v", out["body"])
+	}
+}
+
+// TestDTNStatusUnknownJob returns 404 for an unknown id.
+func TestDTNStatusUnknownJob(t *testing.T) {
+	s := newDTNTestServer(t)
+	code, _ := dtnStatus(t, s, "does-not-exist")
+	if code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown job, got %d", code)
+	}
+}
+
+// TestDTNPersistenceReload verifies jobs survive a store reload (process restart).
+func TestDTNPersistenceReload(t *testing.T) {
+	defer setupTestModeWithLatency(50 * time.Millisecond)()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+
+	dir := t.TempDir()
+	path := dir + "/dtn.json"
+	sec := NewSecurityValidator()
+
+	store1 := NewDTNStore(path, sec, NewTestMetricsCollector())
+	// Loopback (allowed in test mode) so the scheduled fetch stays local.
+	job, err := store1.Add("Mars", "GET", "http://127.0.0.1:80/", nil, "", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// A fresh store loads the persisted job.
+	store2 := NewDTNStore(path, sec, NewTestMetricsCollector())
+	if got, ok := store2.Get(job.ID); !ok || got.Body != "Mars" {
+		t.Fatalf("reloaded store missing job %s", job.ID)
+	}
+}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -61,6 +61,7 @@ type Server struct {
 	metrics            *MetricsCollector
 	security           *SecurityValidator
 	limiter            *RateLimiter // Per-IP rate/concurrency abuse controls
+	dtn                *DTNStore    // Store-and-forward delivery for distant bodies
 	httpServer         *http.Server
 	httpsServer        *http.Server
 	socksListener      net.Listener // Listener for the SOCKS5 server
@@ -71,7 +72,7 @@ type Server struct {
 
 // NewServer creates and returns a new Server instance.
 func NewServer(port int, useHTTPS bool, httpEn bool, socksEn bool, fixedBody string) *Server {
-	return &Server{
+	s := &Server{
 		port:               port,
 		https:              useHTTPS,
 		metrics:            NewMetricsCollector(),
@@ -81,6 +82,14 @@ func NewServer(port int, useHTTPS bool, httpEn bool, socksEn bool, fixedBody str
 		socksEnabled:       socksEn,
 		fixedCelestialBody: fixedBody,
 	}
+	// Store-and-forward jobs persist across restarts (DTN latencies span hours to
+	// days). Path is overridable for tests/ops via DTN_STORE_PATH.
+	storePath := os.Getenv("DTN_STORE_PATH")
+	if storePath == "" {
+		storePath = "/data/dtn-jobs.json"
+	}
+	s.dtn = NewDTNStore(storePath, s.security, s.metrics)
+	return s
 }
 
 // clientIP extracts the bare IP (no port) from a net.Addr string.
@@ -102,6 +111,11 @@ func (s *Server) Start() error {
 	stopCleanup := make(chan struct{})
 	defer close(stopCleanup)
 	go s.limiter.StartCleanup(stopCleanup)
+
+	// Recover any in-flight store-and-forward jobs and start their retention sweep.
+	if s.dtn != nil {
+		s.dtn.Start(stopCleanup)
+	}
 
 	// Use a WaitGroup to wait for server goroutines to finish
 	var wg sync.WaitGroup
@@ -205,6 +219,12 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	// API endpoint for status data
 	if r.URL.Path == "/api/status-data" {
 		s.handleStatusData(w, r)
+		return
+	}
+
+	// Store-and-forward (DTN) API for bodies too distant to proxy synchronously.
+	if strings.HasPrefix(r.URL.Path, "/dtn/") {
+		s.handleDTN(w, r)
 		return
 	}
 
@@ -644,6 +664,13 @@ func (s *Server) printHelp(w http.ResponseWriter) {
 	fmt.Fprintln(w, "---------------------------------")
 	fmt.Fprintln(w, "https://mars.latency.space/           - a body's info page")
 	fmt.Fprintln(w, "https://phobos.mars.latency.space/    - a moon (under its planet)")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Store-and-Forward (DTN) - for distant bodies:")
+	fmt.Fprintln(w, "---------------------------------------------")
+	fmt.Fprintln(w, "Distant bodies (hours/days away) exceed live-proxy timeouts, so requests")
+	fmt.Fprintln(w, "are delivered asynchronously - submit now, poll for the response later:")
+	fmt.Fprintln(w, "  POST https://voyager-1.latency.space/dtn/send   {\"url\":\"https://example.com/\"}")
+	fmt.Fprintln(w, "  GET  https://voyager-1.latency.space/dtn/status/{id}")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Debug Endpoints:")
 	fmt.Fprintln(w, "---------------")

--- a/proxy/src/security.go
+++ b/proxy/src/security.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"sort"
 	"strconv" // Required for port conversion in ValidateSocksDestination
@@ -99,6 +100,39 @@ func NewSecurityValidator() *SecurityValidator {
 		},
 		allowedHosts: allowedHostsMap,
 	}
+}
+
+// ValidateHTTPTarget validates a destination URL for the DTN store-and-forward
+// path: it defaults a missing scheme to https, then enforces the same
+// scheme/host/port allowlist the SOCKS path uses. Returns the normalized URL.
+func (s *SecurityValidator) ValidateHTTPTarget(raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("url is required")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %v", err)
+	}
+	if !s.allowedSchemes[strings.ToLower(u.Scheme)] {
+		return "", fmt.Errorf("scheme %q is not allowed", u.Scheme)
+	}
+	host := u.Hostname()
+	// Loopback is permitted only in test mode (tests use local echo servers on
+	// arbitrary ports); in production isTestMode is false, so loopback falls
+	// through to the allowlist check and is rejected like any other IP literal.
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() && isTestMode.Load() {
+		return u.String(), nil
+	}
+	if p := u.Port(); p != "" && !s.allowedPorts[p] {
+		return "", fmt.Errorf("port %q is not allowed", p)
+	}
+	if !s.IsAllowedHost(host) {
+		return "", fmt.Errorf("host %q is not allowed", host)
+	}
+	return u.String(), nil
 }
 
 // IsAllowedHost checks if the destination host (or its parent domain) is in the allowed list.

--- a/proxy/src/templates/info_page.html
+++ b/proxy/src/templates/info_page.html
@@ -147,6 +147,12 @@
             <pre><code>ssh -o ProxyCommand="nc -X 5 -x {{.Domain}}:1080 %h %p" your-server.com</code></pre>
             <p>3. Browser Configuration: Set SOCKS5 proxy to Host <code>{{.Domain}}</code>, Port <code>1080</code>.</p>
             <p style="font-size: 0.9em; color: #94a3b8;">Note: destination hosts are restricted to an allowlist.</p>
+
+            <h2>Store-and-Forward (distant bodies)</h2>
+            <p>When the round trip is longer than a normal client will wait, deliver requests asynchronously
+               instead: submit one and poll for the response.</p>
+            <pre><code>curl -X POST https://{{.Domain}}/dtn/send -d '{"url":"https://example.com/"}'
+curl https://{{.Domain}}/dtn/status/&lt;id&gt;</code></pre>
         </div>
 
         <hr style="border-color: #334155; margin-top: 40px; margin-bottom: 20px;">

--- a/status/src/pages/Landing.jsx
+++ b/status/src/pages/Landing.jsx
@@ -141,6 +141,15 @@ export default function LandingPage() {
             </div>
 
             <div>
+              <h4 className="mb-3 text-xl font-bold text-white">Store &amp; Forward (distant bodies)</h4>
+              <p className="mb-4 text-slate-400">Bodies hours or days away exceed any client timeout, so requests are delivered asynchronously: submit one, poll for the response. The server models both light-travel legs.</p>
+              <div className="space-y-4">
+                <Guide label="Submit" code={'curl -X POST https://voyager-1.latency.space/dtn/send -d \'{"url":"https://example.com/"}\''} note="Returns a job id immediately." />
+                <Guide label="Poll" code="curl https://voyager-1.latency.space/dtn/status/<id>" note="Response appears once state is 'delivered'." />
+              </div>
+            </div>
+
+            <div>
               <h4 className="mb-3 text-xl font-bold text-white">Debug &amp; Info Endpoints</h4>
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <Endpoint title="Distances" url="/_debug/distances" note="Current distances from Earth to all bodies." />


### PR DESCRIPTION
Implements the distant-object approach chosen in review: **async store-and-forward** (DTN), the only way to deliver to bodies whose latency exceeds any client timeout.

## Why

A transparent proxy can't serve Voyager 1 (~24h one-way): the client socket times out long before the simulated delay elapses (`socks.go` would `time.Sleep` for a day before replying). Real deep-space networks don't hold a live connection either — they store and forward. This mirrors that.

## API

```
POST /dtn/send         { "url", "method", "headers", "payload", "via" }  -> job id
GET  /dtn/status/{id}                                                    -> response once delivered
```

The body comes from the host subdomain (`voyager-1.latency.space`) or a `"via"` field. The server models **both** light-travel legs: the request "arrives" at `submit + one-way` (fetched then), and the response is "delivered" `one-way` later. States: `in_transit → arriving → returning → delivered/failed`. The fetched response is withheld until it has finished travelling back.

## Design

- `dtn.go` — `DTNJob` + `DTNStore`: JSON-file persistence, timer-scheduled fetch, **restart recovery** (reschedules/catches-up pending jobs on boot), 7-day retention janitor. `Get`/`Add` return snapshots taken under the lock (race-clean).
- `dtn_http.go` — the `/dtn` handlers; 1 MiB body caps; rate-limited on submit.
- `security.go` — `ValidateHTTPTarget` reuses the scheme/host/port allowlist (loopback allowed only in test mode, mirroring SOCKS). Same SSRF posture as the SOCKS path.
- `docker-compose.yml` — `proxy_data` volume at `/data` so jobs survive redeploys (RTT can be days).
- Docs: README, per-body info page, landing usage guide, `/_debug/help`.

## Tests

`dtn_test.go`: full lifecycle (submit → in-transit → delivered, response withheld early), allowlist rejection, body-required, unknown-job 404, persistence reload. **Full suite passes under `-race`** across repeated runs.

## Scope

Poll-based MVP. Webhook callback on delivery is a natural follow-up. In-memory + JSON file store is right for this scale; could move to SQLite if job volume grows.