### PR TITLE
Harden DTN: block redirect SSRF, cap jobs, keep Earth non-proxyable

### DIFF
--- a/proxy/src/dtn.go
+++ b/proxy/src/dtn.go
@@ -14,6 +14,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -29,7 +30,11 @@ const (
 	dtnMaxBodyBytes = 1 << 20            // cap stored request/response bodies at 1 MiB
 	dtnRetention    = 7 * 24 * time.Hour // keep delivered jobs this long after delivery
 	dtnFetchTimeout = 60 * time.Second   // real network timeout for the actual fetch
+	dtnMaxJobs      = 512                // hard cap on live jobs, bounding memory + store size
 )
+
+// errDTNStoreFull is returned by Add when the store is at capacity.
+var errDTNStoreFull = errors.New("DTN store is at capacity; try again later")
 
 // DTNJob is a single store-and-forward request and its (eventual) response.
 type DTNJob struct {
@@ -226,7 +231,22 @@ func (s *DTNStore) fetch(method, rawURL string, headers map[string]string, body 
 			req.Header.Set(k, v)
 		}
 	}
-	client := &http.Client{Timeout: dtnFetchTimeout}
+	client := &http.Client{
+		Timeout: dtnFetchTimeout,
+		// Re-validate every redirect hop against the allowlist. Without this an
+		// open redirect on an allowlisted host could bounce the fetch to
+		// 169.254.169.254 / 127.0.0.1 / internal services and return the body
+		// via /dtn/status - an SSRF that defeats the initial-URL allowlist.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if _, err := s.security.ValidateHTTPTarget(req.URL.String()); err != nil {
+				return fmt.Errorf("redirect to disallowed target: %w", err)
+			}
+			return nil
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, "", fmt.Sprintf("fetch: %v", err)
@@ -283,6 +303,10 @@ func (s *DTNStore) Add(bodyName, method, rawURL string, headers map[string]strin
 	}
 
 	s.mu.Lock()
+	if len(s.jobs) >= dtnMaxJobs {
+		s.mu.Unlock()
+		return nil, errDTNStoreFull
+	}
 	s.jobs[j.ID] = j
 	s.scheduleFetchLocked(j)
 	s.save()

--- a/proxy/src/dtn_http.go
+++ b/proxy/src/dtn_http.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -68,8 +69,22 @@ func (s *Server) handleDTNSend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	oneWay := CalculateLatency(getCurrentDistance(bodyName))
+	// Refuse bodies with negligible latency (Earth is 0). Without the light-travel
+	// friction DTN would be a plain open proxy, which the SOCKS path also guards
+	// against; keep Earth non-proxyable. Skipped in test mode, like the SOCKS guard.
+	if !isTestMode.Load() && oneWay < time.Second {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": bodyName + " has insufficient latency to proxy (it would be an open proxy)",
+		})
+		return
+	}
+
 	job, err := s.dtn.Add(bodyName, req.Method, req.URL, req.Headers, req.Payload, oneWay)
 	if err != nil {
+		if errors.Is(err, errDTNStoreFull) {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+			return
+		}
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
 	}

--- a/proxy/src/dtn_test.go
+++ b/proxy/src/dtn_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -140,6 +141,74 @@ func TestDTNRequiresBody(t *testing.T) {
 	}
 	if out["body"] != "Jupiter" {
 		t.Errorf("expected body Jupiter, got %v", out["body"])
+	}
+}
+
+// TestDTNRedirectSSRFBlocked verifies a redirect to a non-allowlisted host is
+// refused (not followed), so the response is never delivered.
+func TestDTNRedirectSSRFBlocked(t *testing.T) {
+	defer setupTestModeWithLatency(40 * time.Millisecond)()
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+
+	// Allowlisted-in-test-mode loopback origin that redirects to a host that is
+	// NOT on the allowlist (simulating an open redirect -> internal/SSRF target).
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://evil.not-listed-anywhere.example/secret", http.StatusFound)
+	}))
+	defer dest.Close()
+
+	s := newDTNTestServer(t)
+	code, out := dtnSend(t, s, "mars.latency.space", fmt.Sprintf(`{"url":%q}`, dest.URL))
+	if code != http.StatusAccepted {
+		t.Fatalf("send: expected 202, got %d (%v)", code, out)
+	}
+	id := out["id"].(string)
+
+	var final map[string]interface{}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_, final = dtnStatus(t, s, id)
+		st := final["state"]
+		if st == "failed" || st == "delivered" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if final["state"] != "failed" {
+		t.Fatalf("expected redirect-to-disallowed to fail, got state %v (response leaked: %v)",
+			final["state"], final["response"])
+	}
+	if _, leaked := final["response"]; leaked {
+		t.Error("SSRF: a blocked redirect must not deliver a response body")
+	}
+}
+
+// TestDTNRejectsEarth verifies zero/negligible-latency bodies are refused
+// outside test mode, keeping DTN from being an open proxy.
+func TestDTNRejectsEarth(t *testing.T) {
+	orig := isTestMode.Load()
+	isTestMode.Store(false) // exercise the production guard
+	defer isTestMode.Store(orig)
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+
+	s := newDTNTestServer(t)
+	code, out := dtnSend(t, s, "earth.latency.space", `{"url":"https://example.com/"}`)
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for Earth (zero latency), got %d (%v)", code, out)
+	}
+}
+
+// TestDTNStoreCapacity verifies Add refuses new jobs once the store is full.
+func TestDTNStoreCapacity(t *testing.T) {
+	defer setupTestMode()()
+	store := NewDTNStore(t.TempDir()+"/dtn.json", NewSecurityValidator(), NewTestMetricsCollector())
+	// Pre-fill the map to the cap without scheduling real fetches.
+	for i := 0; i < dtnMaxJobs; i++ {
+		store.jobs[fmt.Sprintf("job-%d", i)] = &DTNJob{ID: fmt.Sprintf("job-%d", i)}
+	}
+	_, err := store.Add("Mars", "GET", "https://example.com/", nil, "", time.Second)
+	if !errors.Is(err, errDTNStoreFull) {
+		t.Fatalf("expected errDTNStoreFull at capacity, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes from a Fable-model code review of the DTN feature (#88). The review confirmed the concurrency/persistence are sound and found three real issues:

## 1. HIGH — SSRF via unvalidated redirects (was live in production)
The DTN fetch used Go's default `http.Client`, which follows up to 10 redirects, and only the **initial** URL was checked against the allowlist. An open redirect on any allowlisted host (or a host added via `ALLOWED_HOSTS`) could bounce the fetch to `169.254.169.254`, `127.0.0.1`, or internal services (prometheus/grafana/SOCKS containers on the proxy's network), with the body handed back verbatim through `GET /dtn/status/{id}` — a full allowlist bypass.

**Fix:** `CheckRedirect` re-runs `ValidateHTTPTarget` on every hop (loopback/IP-literals rejected in prod) and caps at 10. A redirect to a disallowed host fails the job instead of following it.

## 2. MEDIUM — Unbounded job count
No cap on total jobs; a client could sustain ~60/min, each up to 2 MiB, retained for days, with `save()` rewriting the whole file per op (O(n²)). **Fix:** hard cap `dtnMaxJobs=512`; `Add` returns `errDTNStoreFull` → handler responds **503**.

## 3. MEDIUM — Earth was DTN-proxyable at zero latency
`getCurrentDistance("Earth")` is 0, so DTN became a synchronous open proxy for Earth, violating the "keep Earth non-proxyable" constraint. **Fix:** mirror the SOCKS guard — reject `oneWay < 1s` outside test mode.

## Tests
`TestDTNRedirectSSRFBlocked` (redirect to disallowed → `failed`, no response leaked), `TestDTNRejectsEarth` (→ 400), `TestDTNStoreCapacity` (→ `errDTNStoreFull`). Full suite passes under `-race`; gofmt/vet clean.