### PR TITLE
Fix metrics collection: serve /metrics on :9090 (monitoring was dead)

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -5,7 +5,24 @@ global:
 scrape_configs:
   - job_name: 'latency-proxy'
     static_configs:
-      - targets: ['proxy:9090']  # Using service name for better reliability
+      - targets: ['proxy:9090']  # main proxy (HTTP info pages + DTN)
+
+  # Per-body SOCKS proxies. Each runs the same binary and now exposes /metrics
+  # on :9090 (resolved by docker-compose service name). This is where the actual
+  # proxy-through usage (requests, bandwidth, UDP packets) is recorded.
+  - job_name: 'latency-socks'
+    static_configs:
+      - targets:
+          - 'socks-mars:9090'
+          - 'socks-moon:9090'
+          - 'socks-venus:9090'
+          - 'socks-mercury:9090'
+          - 'socks-jupiter:9090'
+          - 'socks-saturn:9090'
+          - 'socks-europa:9090'
+          - 'socks-titan:9090'
+          - 'socks-voyager1:9090'
+          - 'socks-jwst:9090'
 
   # Node exporter commented due to permission issues
   # - job_name: 'node'

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -117,6 +117,18 @@ func (s *Server) Start() error {
 		s.dtn.Start(stopCleanup)
 	}
 
+	// Expose Prometheus metrics on a dedicated port (this is what Prometheus
+	// scrapes; the /metrics HTTP handler only exists on the proxy's :80/:443 and
+	// not on the SOCKS-only containers). Runs in every container. Configurable/
+	// disableable via METRICS_ADDR; empty disables it.
+	metricsAddr := os.Getenv("METRICS_ADDR")
+	if metricsAddr == "" {
+		metricsAddr = ":9090"
+	}
+	if metricsAddr != "-" {
+		go s.metrics.ServeMetrics(metricsAddr)
+	}
+
 	// Use a WaitGroup to wait for server goroutines to finish
 	var wg sync.WaitGroup
 	// Channel to receive errors from server goroutines

--- a/proxy/src/metrics.go
+++ b/proxy/src/metrics.go
@@ -82,13 +82,14 @@ func (m *MetricsCollector) RecordUDPPacket(body string, bytes int64) {
 	m.bandwidthUsage.WithLabelValues(body, "in").Add(float64(bytes))
 }
 
-// ServeMetrics starts an HTTP server to expose Prometheus metrics on the given address.
+// ServeMetrics starts an HTTP server to expose Prometheus metrics on the given
+// address. Intended to run in its own goroutine. A bind failure is logged but
+// NOT fatal: losing metrics scraping must never take down the proxy itself.
 func (m *MetricsCollector) ServeMetrics(addr string) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	log.Printf("Starting Prometheus metrics server on %s", addr)
-	err := http.ListenAndServe(addr, mux)
-	if err != nil {
-		log.Fatalf("Failed to start metrics server on %s: %v", addr, err)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Printf("metrics server on %s stopped: %v", addr, err)
 	}
 }


### PR DESCRIPTION
Found while answering 'what are the usage stats?' — the answer was *we can't tell*, because monitoring silently collected nothing.

## Root cause
`MetricsCollector.ServeMetrics` (the dedicated `:9090` Prometheus endpoint) is fully implemented but **never called**. So nothing listened on `:9090` in any container, Prometheus's `proxy:9090` target was permanently **DOWN**, and Grafana dashboards were empty. The SOCKS containers (HTTP disabled) exposed metrics *nowhere*, so all proxy-through usage — the main traffic — was uncollectable.

## Fix
- **main.go**: start `ServeMetrics(":9090")` in `Start()` for every container (proxy + SOCKS). `METRICS_ADDR` overrides; `-` disables.
- **metrics.go**: `ServeMetrics` no longer `log.Fatalf`s on bind failure — losing metrics must never crash the proxy.
- **prometheus.yml**: add the per-body SOCKS containers as scrape targets.

After deploy, `proxy:9090` comes up (existing target goes healthy) and, once Prometheus reloads, the SOCKS jobs report real request/bandwidth/UDP counts.

Build/test/gofmt clean.