### PR TITLE
Prometheus: scrape proxy by static IP (Docker DNS broken)

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -3,26 +3,21 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
+  # Target by static IP, NOT service name: this host's Docker embedded DNS
+  # resolves compose service names to the host's public IP (broken daemon DNS,
+  # masked elsewhere because the app addresses core services by static IP), so
+  # 'proxy:9090' never scraped.
   - job_name: 'latency-proxy'
     static_configs:
-      - targets: ['proxy:9090']  # main proxy (HTTP info pages + DTN)
+      - targets: ['172.18.0.2:9090']  # main proxy (HTTP info pages + DTN), static IP
 
-  # Per-body SOCKS proxies. Each runs the same binary and now exposes /metrics
-  # on :9090 (resolved by docker-compose service name). This is where the actual
-  # proxy-through usage (requests, bandwidth, UDP packets) is recorded.
-  - job_name: 'latency-socks'
-    static_configs:
-      - targets:
-          - 'socks-mars:9090'
-          - 'socks-moon:9090'
-          - 'socks-venus:9090'
-          - 'socks-mercury:9090'
-          - 'socks-jupiter:9090'
-          - 'socks-saturn:9090'
-          - 'socks-europa:9090'
-          - 'socks-titan:9090'
-          - 'socks-voyager1:9090'
-          - 'socks-jwst:9090'
+  # Per-body SOCKS proxies now expose /metrics on :9090, but they currently get
+  # DYNAMIC IPs (172.18.0.128/25) so they can't be pinned here. To collect their
+  # request/bandwidth/UDP usage, assign each a static IP in docker-compose.yml
+  # (e.g. 172.18.0.10-.19) and list those IPs here.
+  # - job_name: 'latency-socks'
+  #   static_configs:
+  #     - targets: ['172.18.0.10:9090', ...]
 
   # Node exporter commented due to permission issues
   # - job_name: 'node'


### PR DESCRIPTION
Follow-up to #91. After serving metrics on :9090, the scrape still failed: this host's Docker embedded DNS resolves compose **service names to the host's public IP** (a broken daemon DNS, invisible until now because the app addresses everything by static IP). Point the proxy target at `172.18.0.2:9090` (its static IP) so HTTP+DTN metrics collect. SOCKS containers are on dynamic IPs (`.128/25`) so they're left commented with instructions to assign static IPs first.