### PR TITLE
Static IPs for SOCKS containers + per-body metrics scraping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.10
     logging:
       driver: "json-file"
       options:
@@ -68,6 +69,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.11
     logging:
       driver: "json-file"
       options:
@@ -87,6 +89,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.12
     logging:
       driver: "json-file"
       options:
@@ -106,6 +109,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.13
     logging:
       driver: "json-file"
       options:
@@ -125,6 +129,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.14
     logging:
       driver: "json-file"
       options:
@@ -144,6 +149,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.15
     logging:
       driver: "json-file"
       options:
@@ -165,6 +171,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.16
     logging:
       driver: "json-file"
       options:
@@ -184,6 +191,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.17
     logging:
       driver: "json-file"
       options:
@@ -205,6 +213,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.18
     logging:
       driver: "json-file"
       options:
@@ -224,6 +233,7 @@ services:
     restart: unless-stopped
     networks:
       space-net:
+        ipv4_address: 172.18.0.19
     logging:
       driver: "json-file"
       options:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -11,13 +11,32 @@ scrape_configs:
     static_configs:
       - targets: ['172.18.0.2:9090']  # main proxy (HTTP info pages + DTN), static IP
 
-  # Per-body SOCKS proxies now expose /metrics on :9090, but they currently get
-  # DYNAMIC IPs (172.18.0.128/25) so they can't be pinned here. To collect their
-  # request/bandwidth/UDP usage, assign each a static IP in docker-compose.yml
-  # (e.g. 172.18.0.10-.19) and list those IPs here.
-  # - job_name: 'latency-socks'
-  #   static_configs:
-  #     - targets: ['172.18.0.10:9090', ...]
+  # Per-body SOCKS proxies (the actual proxy-through usage: requests, bandwidth,
+  # UDP packets). Pinned by the static IPs assigned in docker-compose.yml
+  # (service names can't be used - this host's Docker DNS resolves them to the
+  # host IP). The `body` label lets us tell them apart in queries/Grafana.
+  - job_name: 'latency-socks'
+    static_configs:
+      - targets: ['172.18.0.10:9090']
+        labels: {body: mars}
+      - targets: ['172.18.0.11:9090']
+        labels: {body: moon}
+      - targets: ['172.18.0.12:9090']
+        labels: {body: venus}
+      - targets: ['172.18.0.13:9090']
+        labels: {body: mercury}
+      - targets: ['172.18.0.14:9090']
+        labels: {body: jupiter}
+      - targets: ['172.18.0.15:9090']
+        labels: {body: saturn}
+      - targets: ['172.18.0.16:9090']
+        labels: {body: europa}
+      - targets: ['172.18.0.17:9090']
+        labels: {body: titan}
+      - targets: ['172.18.0.18:9090']
+        labels: {body: voyager1}
+      - targets: ['172.18.0.19:9090']
+        labels: {body: jwst}
 
   # Node exporter commented due to permission issues
   # - job_name: 'node'


### PR DESCRIPTION
Completes the monitoring fix and permanently closes the latent IP-collision bug.

## Why
The 10 `socks-*` containers had **dynamic** IPs (`172.18.0.128/25`), so Prometheus couldn't target them (this host's Docker DNS resolves service names to the host IP), leaving all per-body proxy-through usage uncollected. Dynamic allocation starting near `.2` was also the root of the `.2-.5` collision bug noted in ops.

## Change
- **docker-compose.yml**: pin each socks service to a static IP `172.18.0.10`–`.19` — outside the core `.2-.5` and the `.128/25` dynamic pool, so no collisions (verified all 14 static IPs unique).
- **prometheus.yml**: add the `latency-socks` job targeting those IPs, each labelled with its `body`, so requests/bandwidth/UDP break down per body in Grafana.

## Deploy note
`docker compose up -d` will recreate the socks containers with their new fixed IPs (brief per-body blip). After deploy, `docker restart latency-space-prometheus-1` to reload the scrape config, then all 11 targets should be UP.

compose + prometheus YAML validated.