### PR TITLE
Provision Grafana datasource + pin monitoring image versions

### DIFF
--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -1,16 +1,19 @@
 # monitoring/grafana/Dockerfile
-FROM grafana/grafana:latest
+FROM grafana/grafana:13.1.0
 
 # Create Grafana directories
 USER root
-RUN mkdir -p /etc/grafana/provisioning/dashboards
+RUN mkdir -p /etc/grafana/provisioning/dashboards /etc/grafana/provisioning/datasources
 
 # Copy dashboards and config
 COPY dashboards /etc/grafana/provisioning/dashboards
 COPY provisioning/dashboards/default.yaml /etc/grafana/provisioning/dashboards/
 
+# Copy the Prometheus datasource (without this the dashboards have no data source)
+COPY provisioning/datasources /etc/grafana/provisioning/datasources
+
 # Fix permissions
-RUN chown -R 472:472 /etc/grafana/provisioning/dashboards
+RUN chown -R 472:472 /etc/grafana/provisioning/dashboards /etc/grafana/provisioning/datasources
 
 # Switch back to Grafana user (uid 472)
 USER 472

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,15 @@
+# Grafana datasource provisioning. Without this Grafana has NO datasource, so
+# the baked dashboards (which reference uid "prometheus") render nothing even
+# when Prometheus is collecting. The URL uses Prometheus's static IP because this
+# host's Docker DNS resolves service names to the host IP (see ops notes); access
+# "proxy" means the Grafana server reaches it over the container network.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://172.18.0.3:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:latest
+FROM prom/prometheus:v3.13.1
 
 # Copy prometheus config
 COPY prometheus.yml /etc/prometheus/prometheus.yml


### PR DESCRIPTION
Follow-up to "any other unmaintained custom images?" — yes, **Grafana**.

## Findings
Of the 4 custom Dockerfiles, `proxy/` and `status/` are built every deploy (fine). The monitoring pair had issues:

1. **Grafana had no datasource.** The repo ships dashboards (referencing `uid: "prometheus"`) but never a datasource — the Dockerfile only copies `dashboards/`. Live check: `GET /api/datasources` → `count: 0`. So Grafana has been a blank UI regardless of Prometheus. Fix: add `provisioning/datasources/prometheus.yml` (uid `prometheus`, pointed at Prometheus's static IP `172.18.0.3:9090` because this host's Docker DNS is broken) and COPY it in the Dockerfile.
2. **Both monitoring images pinned `:latest`** (`prom/prometheus:latest`, `grafana/grafana:latest`) — a rebuild could silently jump versions. Pinned to the currently-running/tested versions: `v3.13.1` and `13.1.0`.

## Deploy note
Needs `docker compose up -d --build grafana prometheus` (baked-config images — same gotcha as before). After that Grafana should auto-provision the datasource and the solar-system dashboard should render.