### PR TITLE
Emit space_latency_seconds so the Grafana dashboard renders

### DIFF
--- a/monitoring/grafana/dashboards/solar-system-latency.json
+++ b/monitoring/grafana/dashboards/solar-system-latency.json
@@ -88,7 +88,8 @@
             "uid": "prometheus"
           },
           "expr": "space_latency_seconds",
-          "refId": "A"
+          "refId": "A",
+          "legendFormat": "{{body}}"
         }
       ],
       "title": "Latency by Planet",
@@ -112,4 +113,3 @@
   "version": 0,
   "weekStart": ""
 }
-

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -129,6 +129,32 @@ func (s *Server) Start() error {
 		go s.metrics.ServeMetrics(metricsAddr)
 	}
 
+	// Publish current per-body latency as a gauge for the "Solar System Latency"
+	// dashboard. Only the main proxy (HTTP enabled) emits it, so there is one
+	// series per body instead of one per SOCKS container.
+	if s.httpEnabled {
+		go func() {
+			publish := func() {
+				for _, obj := range getCelestialObjects() {
+					if d := getCurrentDistance(obj.Name); d > 0 {
+						s.metrics.SetBodyLatency(obj.Name, CalculateLatency(d).Seconds())
+					}
+				}
+			}
+			publish()
+			t := time.NewTicker(30 * time.Second)
+			defer t.Stop()
+			for {
+				select {
+				case <-stopCleanup:
+					return
+				case <-t.C:
+					publish()
+				}
+			}
+		}()
+	}
+
 	// Use a WaitGroup to wait for server goroutines to finish
 	var wg sync.WaitGroup
 	// Channel to receive errors from server goroutines

--- a/proxy/src/metrics.go
+++ b/proxy/src/metrics.go
@@ -14,6 +14,7 @@ type MetricsCollector struct {
 	requestsTotal   *prometheus.CounterVec
 	bandwidthUsage  *prometheus.CounterVec
 	udpPackets      *prometheus.CounterVec // Counter for UDP packets handled by SOCKS UDP associate
+	spaceLatency    *prometheus.GaugeVec   // Current one-way light latency per body (for the dashboard)
 }
 
 // NewMetricsCollector creates and registers Prometheus metrics collectors.
@@ -47,6 +48,13 @@ func NewMetricsCollector() *MetricsCollector {
 			},
 			[]string{"body"}, // Label by celestial body
 		),
+		spaceLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "space_latency_seconds",
+				Help: "Current one-way light-travel latency to each celestial body",
+			},
+			[]string{"body"},
+		),
 	}
 
 	// Register Prometheus metrics.
@@ -54,8 +62,16 @@ func NewMetricsCollector() *MetricsCollector {
 	prometheus.MustRegister(m.requestsTotal)
 	prometheus.MustRegister(m.bandwidthUsage)
 	prometheus.MustRegister(m.udpPackets)
+	prometheus.MustRegister(m.spaceLatency)
 
 	return m
+}
+
+// SetBodyLatency publishes the current one-way latency (seconds) to a body.
+func (m *MetricsCollector) SetBodyLatency(body string, seconds float64) {
+	if m.spaceLatency != nil {
+		m.spaceLatency.WithLabelValues(body).Set(seconds)
+	}
 }
 
 // RecordRequest observes request duration and increments the total request count.

--- a/proxy/src/metrics_mock.go
+++ b/proxy/src/metrics_mock.go
@@ -42,11 +42,20 @@ func NewTestMetricsCollector() *MetricsCollector {
 		[]string{"body"}, // Label by celestial body
 	)
 
+	spaceLatency := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "test_space_latency_seconds",
+			Help: "Current one-way latency per body (test)",
+		},
+		[]string{"body"},
+	)
+
 	// Create the metrics collector without registering the metrics
 	return &MetricsCollector{
 		requestDuration: requestDuration,
 		requestsTotal:   requestsTotal,
 		bandwidthUsage:  bandwidthUsage,
 		udpPackets:      udpPackets,
+		spaceLatency:    spaceLatency,
 	}
 }


### PR DESCRIPTION
Testing the monitoring end to end surfaced a third dead layer: the **dashboard queries `space_latency_seconds`, which was never emitted** (real metrics are `requests_total`, `bandwidth_bytes_total`, `udp_packets_total`, `request_duration_seconds`). So the 'Solar System Latency' panel is blank even now.

Implements the missing metric (which is exactly what the dashboard wants — live per-body latency):
- `metrics.go`: `space_latency_seconds{body}` gauge + `SetBodyLatency()`.
- `main.go`: the main proxy publishes each body's current one-way latency every 30s. Gated to the proxy (`HTTP_ENABLED`) so there's one series per body, not one per SOCKS container.
- `metrics_mock.go`: mirror for tests. Dashboard: label by `{{body}}`.

After deploy + `docker compose up -d --build proxy grafana`, the dashboard renders live latency to all 46 bodies.