### PR TITLE
Fix stale endpoints; add favicon + custom robots.txt

### DIFF
--- a/deploy/update-nginx.sh
+++ b/deploy/update-nginx.sh
@@ -182,6 +182,16 @@ server {
          client_max_body_size 1m;
     }
 
+    # /metrics at the apex -> Go proxy (Prometheus text). Without this it fell
+    # through to the status frontend and returned the SPA HTML.
+    location = /metrics {
+         proxy_pass http://${PROXY_IP}:80;
+         proxy_http_version 1.1;
+         proxy_set_header Host \$host;
+         proxy_set_header X-Real-IP \$remote_addr;
+         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    }
+
     # Proxy root to the status service
     location / {
         # Explicitly exclude debug paths if they are handled by other servers/locations

--- a/proxy/src/dtn.go
+++ b/proxy/src/dtn.go
@@ -330,6 +330,13 @@ func (s *DTNStore) Get(id string) (*DTNJob, bool) {
 	return &snap, true
 }
 
+// Count returns the number of jobs currently held.
+func (s *DTNStore) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.jobs)
+}
+
 func newDTNID() string {
 	var b [12]byte
 	_, _ = rand.Read(b[:])

--- a/proxy/src/endpoints_test.go
+++ b/proxy/src/endpoints_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/latency-space/shared/celestial"
+)
+
+// TestDebugStatusEndpoint covers /_debug/status, which nginx routed but the app
+// previously 404'd.
+func TestDebugStatusEndpoint(t *testing.T) {
+	setCelestialObjects(celestial.InitSolarSystemObjects())
+	s := &Server{security: NewSecurityValidator(), metrics: NewTestMetricsCollector(), httpEnabled: true}
+	s.dtn = NewDTNStore(t.TempDir()+"/dtn.json", s.security, s.metrics)
+
+	req := httptest.NewRequest(http.MethodGet, "http://latency.space/_debug/status", nil)
+	rec := httptest.NewRecorder()
+	s.handleHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("status response not JSON: %v", err)
+	}
+	for _, k := range []string{"httpEnabled", "socksEnabled", "celestialObjects", "allowedHosts", "dtnJobs"} {
+		if _, ok := out[k]; !ok {
+			t.Errorf("status JSON missing key %q (got %v)", k, out)
+		}
+	}
+}
+
+// TestRobotsTxt verifies body hosts serve a Disallow-all robots.txt.
+func TestRobotsTxt(t *testing.T) {
+	s := &Server{security: NewSecurityValidator(), metrics: NewTestMetricsCollector()}
+	req := httptest.NewRequest(http.MethodGet, "http://mars.latency.space/robots.txt", nil)
+	rec := httptest.NewRecorder()
+	s.handleHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain, got %q", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "Disallow: /") {
+		t.Errorf("robots.txt should disallow all, got %q", rec.Body.String())
+	}
+}

--- a/proxy/src/main.go
+++ b/proxy/src/main.go
@@ -254,6 +254,15 @@ func (s *Server) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// robots.txt: the per-body hosts are proxy/info endpoints, not content to
+	// index - tell crawlers to stay out. (The apex latency.space serves its own
+	// robots.txt from the status frontend.)
+	if r.URL.Path == "/robots.txt" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprint(w, "User-agent: *\nDisallow: /\n")
+		return
+	}
+
 	// API endpoint for status data
 	if r.URL.Path == "/api/status-data" {
 		s.handleStatusData(w, r)
@@ -556,8 +565,32 @@ func (s *Server) handleDebugEndpoint(w http.ResponseWriter, r *http.Request) {
 		s.printAllowedHosts(w)
 	case "help":
 		s.printHelp(w)
+	case "status":
+		s.printStatus(w)
 	default:
 		http.Error(w, "Unknown debug command: "+path, http.StatusNotFound)
+	}
+}
+
+// printStatus returns a small JSON summary of the running instance. This backs
+// /_debug/status, which nginx routed but the app previously did not implement.
+func (s *Server) printStatus(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	body := s.fixedCelestialBody
+	if body == "" {
+		body = "dynamic"
+	}
+	status := map[string]interface{}{
+		"httpEnabled":      s.httpEnabled,
+		"socksEnabled":     s.socksEnabled,
+		"celestialBody":    body,
+		"celestialObjects": len(getCelestialObjects()),
+		"allowedHosts":     len(s.security.AllowedHosts()),
+		"allowedPorts":     s.security.AllowedPorts(),
+		"dtnJobs":          s.dtn.Count(),
+	}
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		log.Printf("printStatus: encode error: %v", err)
 	}
 }
 

--- a/status/public/favicon.svg
+++ b/status/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0b1220"/>
+  <ellipse cx="16" cy="16" rx="12.5" ry="6.5" fill="none" stroke="#334155" stroke-width="1.5"/>
+  <circle cx="16" cy="16" r="4.5" fill="#f5b301"/>
+  <circle cx="16" cy="16" r="4.5" fill="none" stroke="#f5b301" stroke-opacity="0.35" stroke-width="3"/>
+  <circle cx="28" cy="16" r="2.6" fill="#38bdf8"/>
+</svg>

--- a/status/public/robots.txt
+++ b/status/public/robots.txt
@@ -1,0 +1,9 @@
+# latency.space - interplanetary network latency simulator
+# The landing page and status dashboard are fine to index. The proxy control
+# surface (debug endpoints, the DTN API, the status-data feed) is not content
+# and should not be crawled. Per-body subdomains serve their own robots.txt
+# (Disallow: /) from the proxy.
+User-agent: *
+Disallow: /_debug/
+Disallow: /dtn/
+Disallow: /api/


### PR DESCRIPTION
Cleanups from the non-body URL audit.

- **`/_debug/status`** — nginx routed it but the app 404'd. Now returns a small JSON status (http/socks enabled, celestial-object count, allowlist size, DTN job count); adds `DTNStore.Count()`.
- **Apex `/metrics`** — fell through to the status frontend (returned SPA HTML). Added an nginx `location = /metrics` proxying to the Go app so it returns real Prometheus text.
- **`/robots.txt` & `/favicon.svg`** — returned SPA HTML (no such files). Added `status/public/{favicon.svg,robots.txt}` (Vite serves them at the root): a themed favicon and a **custom robots.txt** that allows the dashboard but disallows `/_debug/`, `/dtn/`, `/api/`. Per-body hosts now serve their own `Disallow: /` robots.txt from the proxy.

Tests added for `/_debug/status` and `/robots.txt`; full suite + frontend build pass.