### PR TITLE
Reliable deploy sync + Cloudflare cache-purge workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,15 +237,29 @@ jobs:
               fi
             fi
             
-            # Pull latest code with error handling
-            echo "Pulling latest code..."
-            if ! git pull; then
-              echo "Git pull failed, trying with force option..."
-              git reset --hard HEAD
-              if ! git pull --force; then
-                echo "Git pull failed even with force option"
-                exit 1
+            # Sync the working tree to the EXACT commit that triggered this
+            # deploy. Plain `git pull` occasionally landed a commit behind
+            # (GitHub read-replica lag right after a merge), which built images
+            # from stale source. Hard-reset to the expected SHA and retry until
+            # origin has propagated it.
+            EXPECTED="${{ github.sha }}"
+            echo "Syncing to ${EXPECTED:-origin/main}..."
+            git config --global --add safe.directory /opt/latency-space || true
+            SYNCED=""
+            for attempt in 1 2 3 4 5 6; do
+              git fetch --quiet origin main || true
+              git reset --hard origin/main || true
+              CURRENT=$(git rev-parse HEAD)
+              if [ -z "$EXPECTED" ] || [ "$CURRENT" = "$EXPECTED" ]; then
+                echo "Synced to $CURRENT"
+                SYNCED=1
+                break
               fi
+              echo "HEAD=$CURRENT expected=$EXPECTED (attempt $attempt); waiting for origin to propagate..."
+              sleep 5
+            done
+            if [ -z "$SYNCED" ]; then
+              echo "WARNING: could not reach $EXPECTED; proceeding at $(git rev-parse HEAD)"
             fi
             
             # NB: no blanket stop/rm of containers here. update.sh does a rolling

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -1,0 +1,59 @@
+name: Purge Cloudflare Cache
+
+# Cloudflare caches apex (latency.space) responses at its edge, so changes to
+# static content (favicon, robots.txt, the SPA bundle) can be shadowed by a
+# stale cached copy. Run this after such a change. Manual only.
+#
+# The token (CLOUDFLARE_API_TOKEN, production environment) needs Zone:Read and
+# Zone:Cache Purge on the latency.space zone.
+
+on:
+  workflow_dispatch:
+    inputs:
+      urls:
+        description: "Comma-separated URLs to purge; leave empty to purge everything"
+        type: string
+        default: ""
+
+concurrency:
+  group: purge-cache
+  cancel-in-progress: false
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Purge Cloudflare cache
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          URLS: ${{ inputs.urls }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CF_TOKEN:-}" ]; then
+            echo "CLOUDFLARE_API_TOKEN is not set"; exit 1
+          fi
+
+          ZONE=$(curl -s -H "Authorization: Bearer $CF_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones?name=latency.space" \
+            | jq -r '.result[0].id // empty')
+          if [ -z "$ZONE" ]; then
+            echo "Could not resolve zone id for latency.space (token needs Zone:Read)"; exit 1
+          fi
+          echo "zone: $ZONE"
+
+          if [ -z "${URLS:-}" ]; then
+            BODY='{"purge_everything":true}'
+          else
+            BODY=$(printf '%s' "$URLS" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0)) | {files: .}')
+          fi
+          echo "purge body: $BODY"
+
+          RESP=$(curl -s -X POST \
+            -H "Authorization: Bearer $CF_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.cloudflare.com/client/v4/zones/$ZONE/purge_cache" \
+            --data "$BODY")
+          echo "$RESP" | jq .
+          echo "$RESP" | jq -e '.success == true' >/dev/null || { echo "purge failed"; exit 1; }
+          echo "purge succeeded"


### PR DESCRIPTION
Fixes the two operational frictions surfaced this session.

## 1. Deploy git-sync lag (root cause)
The SSH deploy ran plain `git pull`, which **occasionally landed a commit behind** — GitHub read-replica lag right after a merge — so the VPS rebuilt images from stale source and changes only went live on the *next* deploy (observed with #93, #96). Replaced with a hard-reset to the exact `${{ github.sha }}` that triggered the run, retrying (6× / 5s) until origin has propagated it. Guarantees the deploy builds the intended commit. This also indirectly fixes the "baked-config images didn't update" symptom, which was a downstream effect of the lag.

## 2. Cloudflare cache-purge workflow
Cloudflare caches apex static content (favicon, robots.txt, SPA bundle) at its edge, so a change is shadowed by the stale cached copy (exactly what's happening to the new `/favicon.svg` + `/robots.txt` right now). Adds a manual `workflow_dispatch` that purges specific URLs (comma-separated input) or the whole zone via the existing `CLOUDFLARE_API_TOKEN`.

Note: the token needs **Zone:Read + Cache Purge** on the latency.space zone (currently scoped for DNS edit); if it lacks Cache Purge the run fails cleanly with the API error.

Both workflow YAMLs validated.